### PR TITLE
Fixes for HLTV parser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -205,24 +205,27 @@ class HLTV extends ParsingTools {
 
         let matches = []
         for(let i = 0; i < pages; i++) {
-            const response = await fetch(`${HLTV_URL}/results/${i*50}/`).then(res => res.text())
+            const response = await fetch(`${HLTV_URL}/results?offset=${i*100}`).then(res => res.text())
             const $ = cheerio.load(response)
-            const $matchElems = $('.matchListRow')
+            const $matchElems = $('.result-con')
 
             $matchElems.each((i, elem) => {
-                const $elem = $(elem)
-                const $team1 = $elem.find('.matchTeam1Cell > a')
-                const $team2 = $elem.find('.matchTeam2Cell > a')
+                const $elem    = $(elem)
+                const $team1   = $elem.find('.team1')
+                const $team2   = $elem.find('.team2')
+                let halfId     = $elem.find('a').attr('href').replace('/matches/', '')
+                let slashIndex = halfId.indexOf('/')
 
                 let match = {}
 
-                match.format  = $elem.find('.matchTimeCell').text()
-                match.team1   = $team1.text().trim()
-                match.team2   = $team2.text().trim()
-                match.team1Id = this._getTeamId($team1)
-                match.team2Id = this._getTeamId($team2)
-                match.id      = $elem.find('.matchActionCell > a').attr('href').replace('/match/', '')
-                match.result  = $elem.find('.matchScoreCell').text().trim()
+                match.format   = $elem.find('.map-text').text()
+                match.team1    = $team1.text().trim()
+                match.team2    = $team2.text().trim()
+                match.team1Id  = this._getTeamIdByLogo($team1.find('.team-logo'))
+                match.team2Id  = this._getTeamIdByLogo($team2.find('.team-logo'))
+                match.id       = halfId.substring(0,slashIndex)
+                match.result   = $elem.find('.result-score').text().trim()
+                match.unixtime = $elem.attr('data-zonedgrouping-entry-unix')
 
                 this._restructureMatch(match)
 
@@ -281,8 +284,7 @@ class HLTV extends ParsingTools {
         const $streams = $('.streams')
         const $players = $('.player')
         const $headtohead = $('.head-to-head')
-        /*const $playerHighlight = $('.headertext').find('a > b')
-*/
+
         let teams = []
         $teams.find('.team').each(function( index ) {
             teams.push($( this ))

--- a/src/index.js
+++ b/src/index.js
@@ -164,19 +164,18 @@ class HLTV extends ParsingTools {
         let streams = []
         const response = await fetch(HLTV_URL).then(res => res.text())
         const $ = cheerio.load(response)
-        const $streamTitles = $('div[style*="width: 95px;"]')
-        const $streamViewers = $('div[style*="width: 35px;"]')
+        const $unparsedStreams = $('a.col-box.streamer.a-reset')
 
-        for(let i = 0; i < $streamTitles.length; i++) {
+        for(let i = 0; i < $unparsedStreams.length; i++) {
             let stream = {}
 
-            const $streamHref = $($streamTitles[i]).find('a')
+            const $streamObj = $($unparsedStreams[i])
 
-            stream.name     = $streamHref.attr('title')
-            stream.viewers  = parseInt($($streamViewers[i]).text().replace(/[()]/g, ''))
-            stream.category = $($streamHref.find('img')[0]).attr('title')
-            stream.country  = $($streamHref.find('img')[1]).attr('src').split('flag/')[1].split('.')[0]
-            stream.hltvLink = HLTV_URL + $streamHref.attr('href')
+            stream.name     = $streamObj.attr('title')
+            stream.viewers  = parseInt($streamObj.clone().children().remove().end().text().replace(/[()]/g, ''));
+            stream.category = $($streamObj.find('img')[0]).attr('title')
+            stream.country  = $($streamObj.find('img')[1]).attr('title')
+            stream.hltvLink = HLTV_URL + $streamObj.attr('href')
 
             if(loadLinks) {
                 const hltvPage = await fetch(stream.hltvLink).then(res => res.text())

--- a/src/index.js
+++ b/src/index.js
@@ -252,19 +252,16 @@ class HLTV extends ParsingTools {
         const response = await fetch(HLTV_URL).then(res => res.text())
         const $ = cheerio.load(response)
 
-        const $threadNames = $('div[style*="width: 110px"]')
-        const $threadReplyCount = $('div[style*="width: 30px"]')
+        const $threadsArray = $('.activitylist').children();
 
-        for(let i = 0; i < $threadNames.length; i++) {
-            const $thread = $($threadNames[i])
-
+        for(let i = 0; i < $threadsArray.length; i++) {
+            const $thread = $($threadsArray[i])
             threads[i] = {
-                title: this._cleanupString($thread.text()),
-                link: $thread.find('a').attr('href'),
-                replies: parseInt($($threadReplyCount[i]).text().slice(1))
+                title: $thread.find('span').text(),
+                link: $thread.attr('href'),
+                replies: parseInt($thread.clone().children().remove().end().text().replace(/[()]/g, ''))
             }
         }
-
         return threads
     }
 }


### PR DESCRIPTION
SO HLTV updated. There are fixes + some useful updates

**getMatch() changes:**

- date without time


before:

> "12th of November 2016 22:30"


Now:

> "12th of November 2016"


**getMatches() changes:**
ADDED:

- unixtime - String with seconds since Jan 01 1970 (Unix Timestamp)
- link
- eventname
- date

**getLatestResults() changes:**
ADDED:

- unixtime - (String) Start time of match (Unix Timestamp)


**getStreams() changes:**

- country - full name, not iso code. But ISO code could be parsed from picture


Suggestions if you are still interested in this project:
Stop using "Date" and "time" everywhere where you can use unixtime because it is easy to get date/time/year/etc from unix timestamp.