### PR TITLE
getLatestResults() loading 1st page everytime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ class HLTV {
         let matches = []
 
         for (let i = 0; i < pages; i++) {
-            const response = await fetch(`${HLTV_URL}/results??offset=${i*100}/`).then(res => res.text())
+            const response = await fetch(`${HLTV_URL}/results?offset=${i*100}/`).then(res => res.text())
             const $ = cheerio.load(response)
 
             matches = matches.concat(toArray($('.result-con .a-reset')).map(matchEl => {


### PR DESCRIPTION
getLatestResults() loads 1st page everytime.
If you are using (pages: 3) it will load 1st page 3 times.
You could check:
https://www.hltv.org/results??offset=300
"1 - 100 of 23840"
ez typo :)