### PR TITLE
getLatestResults() Is not loading when "/" is on the end

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ class HLTV {
         let matches = []
 
         for (let i = 0; i < pages; i++) {
-            const response = await fetch(`${HLTV_URL}/results?offset=${i*100}/`).then(res => res.text())
+            const response = await fetch(`${HLTV_URL}/results?offset=${i*100}`).then(res => res.text())
             const $ = cheerio.load(response)
 
             matches = matches.concat(toArray($('.result-con .a-reset')).map(matchEl => {


### PR DESCRIPTION
Sorry one more time
https://www.hltv.org/results?offset=300/ - not loading because of slash in the end of string.
Fun moment:
https://www.hltv.org/results??offset=300/ - working but not in right direction
https://www.hltv.org/results??offset=300 - working but not in right direction
https://www.hltv.org/results?offset=300/ - not working at all
https://www.hltv.org/results?offset=300 - works fine

P.S. sorry i didn't check last commit
I am not on my main PC with working space
Now it should work fine