### PR TITLE
Add 'statsId' to getMatch.ts

### DIFF
--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -57,7 +57,8 @@ const getMatch = (config: HLTVConfig) => async ({ id }: { id: number }): Promise
 
     const maps: MapResult[] = toArray($('.mapholder')).map(mapEl => ({
         name: getMapSlug(mapEl.find('.mapname').text()),
-        result: mapEl.find('.results span').text()
+        result: mapEl.find('.results span').text(),
+        statsId : mapEl.find('.results-stats').attr('href').split('/')[4]
     }))
 
     let players: {team1: Player[], team2: Player[]} | undefined

--- a/src/models/MapResult.ts
+++ b/src/models/MapResult.ts
@@ -2,7 +2,8 @@ import MapSlug from '../enums/MapSlug'
 
 interface MapResult {
     readonly name: MapSlug,
-    readonly result: string
+    readonly result: string,
+    readonly statsId: number
 }
 
 export default MapResult


### PR DESCRIPTION
Today is not possible to get stats from each map because not exist a reference in FullMatch.ts.

this is only a idea