### PR TITLE
fix path error when used as as a npm lib

### DIFF
--- a/src/models/FullEvent.ts
+++ b/src/models/FullEvent.ts
@@ -1,6 +1,6 @@
 import Team from './Team'
 import Event from './Event'
-import MapSlug from 'enums/MapSlug'
+import MapSlug from '../enums/MapSlug'
 import Country from './Country'
 
 export interface EventPrizeDistribution {


### PR DESCRIPTION
fix #104 
let `src/models/FullEvent` import `enums/MapSlug` in the same way of `src/models/FullMatchMapStats`