### PR TITLE
Add match score to match stats and match map stats api

### DIFF
--- a/__tests__/__snapshots__/getMatchStats.test.ts.snap
+++ b/__tests__/__snapshots__/getMatchStats.test.ts.snap
@@ -8,6 +8,10 @@ Object {
     "name": "BLAST Pro Series Lisbon 2018",
   },
   "matchPageID": 2329728,
+  "matchScore": Array [
+    2,
+    1,
+  ],
   "overview": Object {
     "bestRating": Object {
       "id": 7398,
@@ -201,10 +205,12 @@ Object {
   "team1": Object {
     "id": 6665,
     "name": "Astralis",
+    "score": 2,
   },
   "team2": Object {
     "id": 4608,
     "name": "Natus Vincere",
+    "score": 1,
   },
 }
 `;
@@ -217,6 +223,10 @@ Object {
     "name": "LOOT.BET Bullet Blizzard",
   },
   "matchPageID": 2330118,
+  "matchScore": Array [
+    1,
+    2,
+  ],
   "overview": Object {
     "bestRating": Object {
       "id": 9008,
@@ -410,10 +420,12 @@ Object {
   "team1": Object {
     "id": 9357,
     "name": "Underdogs",
+    "score": 1,
   },
   "team2": Object {
     "id": 9287,
     "name": "Unique",
+    "score": 2,
   },
 }
 `;
@@ -426,6 +438,10 @@ Object {
     "name": "StarSeries i-League Season 7 Asia Qualifier",
   },
   "matchPageID": 2329953,
+  "matchScore": Array [
+    2,
+    0,
+  ],
   "overview": Object {
     "bestRating": Object {
       "id": 10774,
@@ -619,10 +635,12 @@ Object {
   "team1": Object {
     "id": 7606,
     "name": "ViCi",
+    "score": 2,
   },
   "team2": Object {
     "id": 9483,
     "name": "Sparta",
+    "score": 0,
   },
 }
 `;

--- a/__tests__/__snapshots__/getMatchStats.test.ts.snap
+++ b/__tests__/__snapshots__/getMatchStats.test.ts.snap
@@ -8,10 +8,6 @@ Object {
     "name": "BLAST Pro Series Lisbon 2018",
   },
   "matchPageID": 2329728,
-  "matchScore": Array [
-    2,
-    1,
-  ],
   "overview": Object {
     "bestRating": Object {
       "id": 7398,
@@ -223,10 +219,6 @@ Object {
     "name": "LOOT.BET Bullet Blizzard",
   },
   "matchPageID": 2330118,
-  "matchScore": Array [
-    1,
-    2,
-  ],
   "overview": Object {
     "bestRating": Object {
       "id": 9008,
@@ -438,10 +430,6 @@ Object {
     "name": "StarSeries i-League Season 7 Asia Qualifier",
   },
   "matchPageID": 2329953,
-  "matchScore": Array [
-    2,
-    0,
-  ],
   "overview": Object {
     "bestRating": Object {
       "id": 10774,

--- a/src/endpoints/getMatchMapStats.ts
+++ b/src/endpoints/getMatchMapStats.ts
@@ -1,9 +1,8 @@
 import FullMatchMapStats, {
-    PlayerStat, MatchStatsOverview, TeamStatComparison,
+    TeamStat, PlayerStat, MatchStatsOverview, TeamStatComparison,
     PlayerPerformanceStats, PlayerStats, PerformanceOverview
 } from '../models/FullMatchMapStats'
 import RoundOutcome, { WeakRoundOutcome } from '../models/RoundOutcome'
-import Team from '../models/Team'
 import Event from '../models/Event'
 import * as E from '../utils/parsing'
 import HLTVConfig from '../models/HLTVConfig'
@@ -39,13 +38,13 @@ const getMatchMapStats = (config: HLTVConfig) => async ({ id }: { id: number }):
     const map = getMapSlug(m$(m$('.match-info-box').contents().get(3)).text().replace(/\n| /g, ''))
     const date = Number(m$('.match-info-box .small-text span').first().attr('data-unix'))
 
-    const team1: Team = {
+    const team1: TeamStat = {
         id: Number(E.popSlashSource(m$('.team-left .team-logo'))),
         name: m$('.team-left .team-logo').attr('title'),
         score: matchScore[0],
     }
 
-    const team2: Team = {
+    const team2: TeamStat = {
         id: Number(E.popSlashSource(m$('.team-right .team-logo'))),
         name: m$('.team-right .team-logo').attr('title'),
         score: matchScore[1],
@@ -120,7 +119,7 @@ const getMatchMapStats = (config: HLTVConfig) => async ({ id }: { id: number }):
     }, {} as PerformanceOverview)
 
     return {
-        matchPageID, matchScore, map, date, team1, team2, event, overview, roundHistory, playerStats, performanceOverview
+        matchPageID, map, date, team1, team2, event, overview, roundHistory, playerStats, performanceOverview
     }
 }
 

--- a/src/endpoints/getMatchMapStats.ts
+++ b/src/endpoints/getMatchMapStats.ts
@@ -93,6 +93,8 @@ const getMatchMapStats = (config: HLTVConfig) => async ({ id }: { id: number }):
             name: rowEl.find('.st-player a').text(),
             kills: Number(rowEl.find('.st-kills').contents().first().text()),
             hsKills: Number(rowEl.find('.st-kills .gtSmartphone-only').text().replace(/\(|\)/g, '')),
+            assists: Number(rowEl.find('.st-assists').contents().first().text()),
+            flashAssists: Number(rowEl.find('.st-assists .gtSmartphone-only').text().replace(/\(|\)/g, '')),
             deaths: Number(rowEl.find('.st-deaths').text()),
             KAST: Number(rowEl.find('.st-kdratio').text().replace('%', '')),
             killDeathsDifference: Number(rowEl.find('.st-kddiff').text()),

--- a/src/endpoints/getMatchMapStats.ts
+++ b/src/endpoints/getMatchMapStats.ts
@@ -35,17 +35,20 @@ const getMatchMapStats = (config: HLTVConfig) => async ({ id }: { id: number }):
     ])
 
     const matchPageID = Number(m$('.match-page-link').attr('href').split('/')[2])
+    const matchScore = [ Number(m$('.team-left .bold').text()), Number(m$('.team-right .bold').text()) ]
     const map = getMapSlug(m$(m$('.match-info-box').contents().get(3)).text().replace(/\n| /g, ''))
     const date = Number(m$('.match-info-box .small-text span').first().attr('data-unix'))
 
     const team1: Team = {
         id: Number(E.popSlashSource(m$('.team-left .team-logo'))),
-        name: m$('.team-left .team-logo').attr('title')
+        name: m$('.team-left .team-logo').attr('title'),
+        score: matchScore[0],
     }
 
     const team2: Team = {
         id: Number(E.popSlashSource(m$('.team-right .team-logo'))),
-        name: m$('.team-right .team-logo').attr('title')
+        name: m$('.team-right .team-logo').attr('title'),
+        score: matchScore[1],
     }
 
     const event: Event = {
@@ -115,7 +118,7 @@ const getMatchMapStats = (config: HLTVConfig) => async ({ id }: { id: number }):
     }, {} as PerformanceOverview)
 
     return {
-        matchPageID, map, date, team1, team2, event, overview, roundHistory, playerStats, performanceOverview
+        matchPageID, matchScore, map, date, team1, team2, event, overview, roundHistory, playerStats, performanceOverview
     }
 }
 

--- a/src/endpoints/getMatchStats.ts
+++ b/src/endpoints/getMatchStats.ts
@@ -28,16 +28,19 @@ const getMatchStats = (config: HLTVConfig) => async ({ id }: { id: number }): Pr
     const m$ = await fetchPage(`${config.hltvUrl}/stats/matches/${id}/-`, config.loadPage);
 
     const matchPageID = Number(m$('.match-page-link').attr('href').split('/')[2])
+    const matchScore = [ Number(m$('.team-left .bold').text()), Number(m$('.team-right .bold').text()) ]
     const date = Number(m$('.match-info-box .small-text span').first().attr('data-unix'))
 
     const team1: Team = {
         id: Number(E.popSlashSource(m$('.team-left .team-logo'))),
-        name: m$('.team-left .team-logo').attr('title')
+        name: m$('.team-left .team-logo').attr('title'),
+        score: matchScore[0]
     }
 
     const team2: Team = {
         id: Number(E.popSlashSource(m$('.team-right .team-logo'))),
-        name: m$('.team-right .team-logo').attr('title')
+        name: m$('.team-right .team-logo').attr('title'),
+        score: matchScore[1]
     }
 
     const event: Event = {
@@ -77,7 +80,7 @@ const getMatchStats = (config: HLTVConfig) => async ({ id }: { id: number }): Pr
     }
 
     return {
-        matchPageID, date, team1, team2, event, overview, playerStats,
+        matchPageID, matchScore, date, team1, team2, event, overview, playerStats,
     }
 }
 

--- a/src/endpoints/getMatchStats.ts
+++ b/src/endpoints/getMatchStats.ts
@@ -1,7 +1,6 @@
 import FullMatchStats, {
-    PlayerStat, PlayerStats, MatchStatsOverview, TeamStatComparison 
+    TeamStat, PlayerStat, PlayerStats, MatchStatsOverview, TeamStatComparison 
 } from '../models/FullMatchStats'
-import Team from '../models/Team'
 import Event from '../models/Event'
 import * as E from '../utils/parsing'
 import HLTVConfig from '../models/HLTVConfig'
@@ -31,13 +30,13 @@ const getMatchStats = (config: HLTVConfig) => async ({ id }: { id: number }): Pr
     const matchScore = [ Number(m$('.team-left .bold').text()), Number(m$('.team-right .bold').text()) ]
     const date = Number(m$('.match-info-box .small-text span').first().attr('data-unix'))
 
-    const team1: Team = {
+    const team1: TeamStat = {
         id: Number(E.popSlashSource(m$('.team-left .team-logo'))),
         name: m$('.team-left .team-logo').attr('title'),
         score: matchScore[0]
     }
 
-    const team2: Team = {
+    const team2: TeamStat = {
         id: Number(E.popSlashSource(m$('.team-right .team-logo'))),
         name: m$('.team-right .team-logo').attr('title'),
         score: matchScore[1]
@@ -80,7 +79,7 @@ const getMatchStats = (config: HLTVConfig) => async ({ id }: { id: number }): Pr
     }
 
     return {
-        matchPageID, matchScore, date, team1, team2, event, overview, playerStats,
+        matchPageID, date, team1, team2, event, overview, playerStats,
     }
 }
 

--- a/src/models/FullMatchMapStats.ts
+++ b/src/models/FullMatchMapStats.ts
@@ -33,6 +33,7 @@ export interface PlayerOverviewStats {
     kills: number,
     hsKills: number,
     assists: number,
+    flashAssists: number,
     deaths: number,
     KAST: number,
     killDeathsDifference: number,

--- a/src/models/FullMatchMapStats.ts
+++ b/src/models/FullMatchMapStats.ts
@@ -8,6 +8,10 @@ export interface RoundOutcome extends WeakRoundOutcome {
     outcome: Outcome
 }
 
+export interface TeamStat extends Team {
+    readonly score: number
+}
+
 export interface PlayerStat extends Player {
     readonly value: number
 }
@@ -63,7 +67,6 @@ export interface PerformanceOverview {
 
 interface FullMatchMapStats {
     readonly matchPageID: number,
-    readonly matchScore: number[],
     readonly team1: Team,
     readonly team2: Team,
     readonly event: Event,

--- a/src/models/FullMatchMapStats.ts
+++ b/src/models/FullMatchMapStats.ts
@@ -62,6 +62,7 @@ export interface PerformanceOverview {
 
 interface FullMatchMapStats {
     readonly matchPageID: number,
+    readonly matchScore: number[],
     readonly team1: Team,
     readonly team2: Team,
     readonly event: Event,

--- a/src/models/FullMatchStats.ts
+++ b/src/models/FullMatchStats.ts
@@ -42,6 +42,7 @@ export interface PlayerOverviewStats {
 
 interface FullMatchStats {
     readonly matchPageID: number,
+    readonly matchScore: number[],
     readonly team1: Team,
     readonly team2: Team,
     readonly event: Event,

--- a/src/models/FullMatchStats.ts
+++ b/src/models/FullMatchStats.ts
@@ -2,6 +2,10 @@ import Team from './Team'
 import Event from './Event'
 import Player from './Player'
 
+export interface TeamStat extends Team {
+    readonly score: number
+}
+
 export interface PlayerStat extends Player {
     readonly value: number
 }
@@ -42,7 +46,6 @@ export interface PlayerOverviewStats {
 
 interface FullMatchStats {
     readonly matchPageID: number,
-    readonly matchScore: number[],
     readonly team1: Team,
     readonly team2: Team,
     readonly event: Event,

--- a/src/models/Team.ts
+++ b/src/models/Team.ts
@@ -1,6 +1,7 @@
 interface Team {
     readonly name: string,
-    readonly id?: number
+    readonly id?: number,
+    readonly score?: number
 }
 
 export default Team

--- a/src/models/Team.ts
+++ b/src/models/Team.ts
@@ -1,7 +1,6 @@
 interface Team {
     readonly name: string,
-    readonly id?: number,
-    readonly score?: number
+    readonly id?: number
 }
 
 export default Team


### PR DESCRIPTION
This adds the match score to the response. An example could be the that the match score is "2 - 1", then team1 will have `score: 2` and team2 will have `score: 1`

Furthermore a property `matchScore: [ 2, 1 ]` will be available on the full response object.

Thanks,