### PR TITLE
 Add new log event type

### DIFF
--- a/src/models/LogUpdate.ts
+++ b/src/models/LogUpdate.ts
@@ -47,7 +47,7 @@ export interface Kill {
 
 export interface Assist {
     Assist: {
-        asissterName: string,
+        assisterName: string,
         assisterNick: string,
         assisterSide: Side,
         victimNick: string,

--- a/src/models/LogUpdate.ts
+++ b/src/models/LogUpdate.ts
@@ -1,10 +1,20 @@
 import WinType from '../enums/WinType'
 
 export type Side = 'CT' | 'TERRORIST' | 'SPECTATOR'
-export type LogEvent = RoundStart | RoundEnd | Kill | Assist | BombDefused | BombPlanted | PlayerJoin | PlayerQuit
+export type LogEvent = RoundStart | RoundEnd | Restart | MatchStarted | Kill | Assist | Suicide | BombDefused | BombPlanted | PlayerJoin | PlayerQuit
 
 export interface RoundStart {
     RoundStart: {}
+}
+
+export interface MatchStarted {
+    MatchStarted: {
+        map: string
+    }
+}
+
+export interface Restart {
+    Restart: {}
 }
 
 export interface PlayerJoin {
@@ -54,6 +64,15 @@ export interface Assist {
         victimName: string,
         victimSide: Side,
         killEventId: number
+    }
+}
+
+export interface Suicide {
+    Suicide: {
+        playerName: string,
+        playerNick: string,
+        side: Side,
+        weapon: string
     }
 }
 


### PR DESCRIPTION
This add some new log event types I found.

Data example:

```json
    {
      "Suicide": {
        "playerName": "ROBO",
        "playerNick": "ROBO",
        "side": "CT",
        "weapon": "world"
      }
    },
    {
      "MatchStarted": {
        "map": "de_dust2"
      }
    }
```