### PR TITLE
Adds `qualifiesFor` key to event prize pools, in case spot qualifies team to another event

### DIFF
--- a/__tests__/__snapshots__/getEvent.test.ts.snap
+++ b/__tests__/__snapshots__/getEvent.test.ts.snap
@@ -319,7 +319,9 @@ Object {
     Object {
       "place": "1-2nd",
       "prize": undefined,
-      "qualifiesFor": "Liga TyC Sports Aorus Finals",
+      "qualifiesFor": Object {
+        "name": "Liga TyC Sports Aorus Finals",
+      },
       "team": Object {
         "id": 6799,
         "name": "Furious",
@@ -328,7 +330,9 @@ Object {
     Object {
       "place": "1-2nd",
       "prize": undefined,
-      "qualifiesFor": "Liga TyC Sports Aorus Finals",
+      "qualifiesFor": Object {
+        "name": "Liga TyC Sports Aorus Finals",
+      },
       "team": Object {
         "id": 7653,
         "name": "Isurus",

--- a/__tests__/__snapshots__/getEvent.test.ts.snap
+++ b/__tests__/__snapshots__/getEvent.test.ts.snap
@@ -28,6 +28,7 @@ Object {
     Object {
       "place": "1st",
       "prize": "$4,100",
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 6497,
         "name": "TzatzikiKlubben",
@@ -36,6 +37,7 @@ Object {
     Object {
       "place": "2nd",
       "prize": "$1,175",
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8660,
         "name": "low riders",
@@ -44,6 +46,7 @@ Object {
     Object {
       "place": "3rd",
       "prize": "$575",
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8659,
         "name": "Kampners Advokatbyrå",
@@ -52,6 +55,7 @@ Object {
     Object {
       "place": "4th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 7908,
         "name": "PopcornPlokker$",
@@ -117,6 +121,7 @@ Object {
     Object {
       "place": "1st",
       "prize": "$2,000",
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 6343,
         "name": "EURONICS",
@@ -125,6 +130,7 @@ Object {
     Object {
       "place": "2nd",
       "prize": "$500",
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 6652,
         "name": "GameAgents",
@@ -133,6 +139,7 @@ Object {
     Object {
       "place": "3-4th",
       "prize": "$250",
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8361,
         "name": "SEAL",
@@ -141,6 +148,7 @@ Object {
     Object {
       "place": "3-4th",
       "prize": "$250",
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 7187,
         "name": "Nexus",
@@ -149,6 +157,7 @@ Object {
     Object {
       "place": "5-6th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8572,
         "name": "Codewise Unicorns",
@@ -157,6 +166,7 @@ Object {
     Object {
       "place": "5-6th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 7017,
         "name": "Space Jam",
@@ -165,6 +175,7 @@ Object {
     Object {
       "place": "7-8th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 4929,
         "name": "Refuse",
@@ -173,6 +184,7 @@ Object {
     Object {
       "place": "7-8th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8305,
         "name": "DreamEaters",
@@ -181,6 +193,7 @@ Object {
     Object {
       "place": "9-10th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 6679,
         "name": "Revolution",
@@ -189,6 +202,7 @@ Object {
     Object {
       "place": "9-10th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8209,
         "name": "Pompa",
@@ -305,6 +319,7 @@ Object {
     Object {
       "place": "1-2nd",
       "prize": undefined,
+      "qualifiesFor": "Liga TyC Sports Aorus Finals",
       "team": Object {
         "id": 6799,
         "name": "Furious",
@@ -313,6 +328,7 @@ Object {
     Object {
       "place": "1-2nd",
       "prize": undefined,
+      "qualifiesFor": "Liga TyC Sports Aorus Finals",
       "team": Object {
         "id": 7653,
         "name": "Isurus",
@@ -321,6 +337,7 @@ Object {
     Object {
       "place": "3-4th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8123,
         "name": "Keymotion",
@@ -329,6 +346,7 @@ Object {
     Object {
       "place": "3-4th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8125,
         "name": "Hafnet",
@@ -337,6 +355,7 @@ Object {
     Object {
       "place": "5-8th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8094,
         "name": "Licht",
@@ -345,6 +364,7 @@ Object {
     Object {
       "place": "5-8th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8121,
         "name": "Malvinas",
@@ -353,6 +373,7 @@ Object {
     Object {
       "place": "5-8th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8122,
         "name": "Kitsune",
@@ -361,6 +382,7 @@ Object {
     Object {
       "place": "5-8th",
       "prize": undefined,
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 8124,
         "name": "Keymotion Red",

--- a/__tests__/__snapshots__/getEvent.test.ts.snap
+++ b/__tests__/__snapshots__/getEvent.test.ts.snap
@@ -319,9 +319,7 @@ Object {
     Object {
       "place": "1-2nd",
       "prize": undefined,
-      "qualifiesFor": Object {
-        "name": "Liga TyC Sports Aorus Finals",
-      },
+      "qualifiesFor": "Liga TyC Sports Aorus Finals",
       "team": Object {
         "id": 6799,
         "name": "Furious",
@@ -330,9 +328,7 @@ Object {
     Object {
       "place": "1-2nd",
       "prize": undefined,
-      "qualifiesFor": Object {
-        "name": "Liga TyC Sports Aorus Finals",
-      },
+      "qualifiesFor": "Liga TyC Sports Aorus Finals",
       "team": Object {
         "id": 7653,
         "name": "Isurus",

--- a/__tests__/__snapshots__/getEvent.test.ts.snap
+++ b/__tests__/__snapshots__/getEvent.test.ts.snap
@@ -457,3 +457,464 @@ Object {
   ],
 }
 `;
+
+exports[`getEvent 5`] = `
+Object {
+  "dateEnd": 1549623600000,
+  "dateStart": 1549450800000,
+  "formats": Array [
+    Object {
+      "description": "Double-Elimination BO3 BO5 Grand Final",
+      "type": "Playoffs",
+    },
+  ],
+  "location": Object {
+    "code": "NAM",
+    "name": "North America",
+  },
+  "mapPool": Array [
+    "cch",
+    "d2",
+    "mrg",
+    "inf",
+    "nuke",
+    "trn",
+    "ovp",
+  ],
+  "name": "IEM Sydney 2019 North America Closed Qualifier",
+  "prizeDistribution": Array [
+    Object {
+      "otherPrize": undefined,
+      "place": "1st",
+      "prize": undefined,
+      "qualifiesFor": Object {
+        "id": 4236,
+        "name": "IEM Sydney 2019",
+      },
+      "team": Object {
+        "id": 7726,
+        "name": "Swole Patrol",
+      },
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "2nd",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": Object {
+        "id": 7106,
+        "name": "eUnited",
+      },
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "3rd",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": Object {
+        "id": 7801,
+        "name": "Ghost",
+      },
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "4th",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": Object {
+        "id": 6290,
+        "name": "Luminosity",
+      },
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "5-6th",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": Object {
+        "id": 5005,
+        "name": "compLexity",
+      },
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "5-6th",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": Object {
+        "id": 5991,
+        "name": "Envy",
+      },
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "7-8th",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": Object {
+        "id": 9799,
+        "name": "Bad News Bears",
+      },
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "7-8th",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": Object {
+        "id": 9804,
+        "name": "Win Scrims Not Matches",
+      },
+    },
+  ],
+  "prizePool": "1 spot at IEM Sydney",
+  "relatedEvents": Array [
+    Object {
+      "id": 4236,
+      "name": "IEM Sydney 2019",
+    },
+    Object {
+      "id": 4354,
+      "name": "IEM Sydney 2019 North America Open Qualifier 1",
+    },
+    Object {
+      "id": 4355,
+      "name": "IEM Sydney 2019 North America Open Qualifier 2",
+    },
+  ],
+  "teams": Array [
+    Object {
+      "id": 5991,
+      "name": "Envy",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 7801,
+      "name": "Ghost",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 6290,
+      "name": "Luminosity",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 5005,
+      "name": "compLexity",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 9804,
+      "name": "Win Scrims Not Matches",
+      "reasonForParticipation": "Qualifier 1",
+    },
+    Object {
+      "id": 7106,
+      "name": "eUnited",
+      "reasonForParticipation": "Qualifier 1",
+    },
+    Object {
+      "id": 9799,
+      "name": "Bad News Bears",
+      "reasonForParticipation": "Qualifier 2",
+    },
+    Object {
+      "id": 7726,
+      "name": "Swole Patrol",
+      "reasonForParticipation": "Qualifier 2",
+    },
+  ],
+}
+`;
+
+exports[`getEvent 6`] = `
+Object {
+  "dateEnd": 1549623600000,
+  "dateStart": 1549623600000,
+  "formats": Array [
+    Object {
+      "description": "Round-robin BO1",
+      "type": "Group stage",
+    },
+  ],
+  "location": Object {
+    "code": "EU",
+    "name": "Europe",
+  },
+  "mapPool": Array [
+    "cch",
+    "d2",
+    "mrg",
+    "inf",
+    "nuke",
+    "trn",
+    "ovp",
+  ],
+  "name": "NoxFire League Season 2",
+  "prizeDistribution": Array [
+    Object {
+      "otherPrize": "LAN Finals",
+      "place": "1st",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": "LAN Finals",
+      "place": "2nd",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": "LAN Finals",
+      "place": "3rd",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": "LAN Finals",
+      "place": "4th",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "5th",
+      "prize": "$2,000",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "6th",
+      "prize": "$2,000",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "7th",
+      "prize": "$2,000",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "8th",
+      "prize": "$2,000",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "9th",
+      "prize": "$1,000",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "10th",
+      "prize": "$1,000",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "11th",
+      "prize": "$1,000",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "12th",
+      "prize": "$1,000",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "13th",
+      "prize": "$500",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "14th",
+      "prize": "$500",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "15th",
+      "prize": "$500",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "16th",
+      "prize": "$500",
+      "qualifiesFor": undefined,
+      "team": undefined,
+    },
+  ],
+  "prizePool": "4 Spots at LAN Finals + $14000",
+  "relatedEvents": Array [
+    Object {
+      "id": 4183,
+      "name": "NoxFire League",
+    },
+    Object {
+      "id": 4410,
+      "name": "NoxFire League Season 2 Finals",
+    },
+  ],
+  "teams": Array [
+    Object {
+      "id": 4914,
+      "name": "3DMAX",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 8120,
+      "name": "AVANGAR",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 9679,
+      "name": "Akopalipsa",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 7982,
+      "name": "Bojestvata",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 6762,
+      "name": "Bpro",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 5273,
+      "name": "GamePub",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 6134,
+      "name": "Kinguin",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 7187,
+      "name": "Nexus",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 8504,
+      "name": "SuperJymy",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 9812,
+      "name": "Unicorns of Love",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 8513,
+      "name": "Windigo",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 8135,
+      "name": "forZe",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 7898,
+      "name": "pro100",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 5579,
+      "name": "volgare",
+      "reasonForParticipation": "Invited",
+    },
+    Object {
+      "id": 9838,
+      "name": "Heavy KnockOut",
+      "reasonForParticipation": "Qualifier",
+    },
+    Object {
+      "id": 7615,
+      "name": "HoP",
+      "reasonForParticipation": "Qualifier",
+    },
+  ],
+}
+`;
+
+exports[`getEvent 7`] = `
+Object {
+  "dateEnd": 1495360800000,
+  "dateStart": 1495360800000,
+  "formats": Array [],
+  "location": Object {
+    "code": "SE",
+    "name": "Sweden",
+  },
+  "mapPool": Array [
+    "cch",
+    "mrg",
+    "inf",
+    "nuke",
+    "trn",
+    "cbl",
+    "ovp",
+  ],
+  "name": "GAMERZ Season 1: Nordic Edition",
+  "prizeDistribution": Array [
+    Object {
+      "otherPrize": "Pro contracts",
+      "place": "1st",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": Object {
+        "id": 7930,
+        "name": "GAMERZ BLUE",
+      },
+    },
+    Object {
+      "otherPrize": undefined,
+      "place": "2nd",
+      "prize": undefined,
+      "qualifiesFor": undefined,
+      "team": Object {
+        "id": 7931,
+        "name": "GAMERZ RED",
+      },
+    },
+  ],
+  "prizePool": "Professional contracts",
+  "relatedEvents": Array [],
+  "teams": Array [
+    Object {
+      "id": 7930,
+      "name": "GAMERZ BLUE",
+      "reasonForParticipation": undefined,
+    },
+    Object {
+      "id": 7931,
+      "name": "GAMERZ RED",
+      "reasonForParticipation": undefined,
+    },
+  ],
+}
+`;

--- a/__tests__/__snapshots__/getEvent.test.ts.snap
+++ b/__tests__/__snapshots__/getEvent.test.ts.snap
@@ -26,6 +26,7 @@ Object {
   "name": "Ownit 2017 Winter Finals",
   "prizeDistribution": Array [
     Object {
+      "otherPrize": undefined,
       "place": "1st",
       "prize": "$4,100",
       "qualifiesFor": undefined,
@@ -35,6 +36,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "2nd",
       "prize": "$1,175",
       "qualifiesFor": undefined,
@@ -44,6 +46,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "3rd",
       "prize": "$575",
       "qualifiesFor": undefined,
@@ -53,6 +56,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "4th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -119,6 +123,7 @@ Object {
   "name": "CSesport.com Cup #3",
   "prizeDistribution": Array [
     Object {
+      "otherPrize": undefined,
       "place": "1st",
       "prize": "$2,000",
       "qualifiesFor": undefined,
@@ -128,6 +133,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "2nd",
       "prize": "$500",
       "qualifiesFor": undefined,
@@ -137,6 +143,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "3-4th",
       "prize": "$250",
       "qualifiesFor": undefined,
@@ -146,6 +153,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "3-4th",
       "prize": "$250",
       "qualifiesFor": undefined,
@@ -155,6 +163,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "5-6th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -164,6 +173,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "5-6th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -173,6 +183,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "7-8th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -182,6 +193,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "7-8th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -191,6 +203,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "9-10th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -200,6 +213,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "9-10th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -317,24 +331,27 @@ Object {
   "name": "Liga TyC Sports Aorus #1",
   "prizeDistribution": Array [
     Object {
+      "otherPrize": "Liga TyC Sports Aorus Finals",
       "place": "1-2nd",
       "prize": undefined,
-      "qualifiesFor": "Liga TyC Sports Aorus Finals",
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 6799,
         "name": "Furious",
       },
     },
     Object {
+      "otherPrize": "Liga TyC Sports Aorus Finals",
       "place": "1-2nd",
       "prize": undefined,
-      "qualifiesFor": "Liga TyC Sports Aorus Finals",
+      "qualifiesFor": undefined,
       "team": Object {
         "id": 7653,
         "name": "Isurus",
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "3-4th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -344,6 +361,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "3-4th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -353,6 +371,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "5-8th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -362,6 +381,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "5-8th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -371,6 +391,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "5-8th",
       "prize": undefined,
       "qualifiesFor": undefined,
@@ -380,6 +401,7 @@ Object {
       },
     },
     Object {
+      "otherPrize": undefined,
       "place": "5-8th",
       "prize": undefined,
       "qualifiesFor": undefined,

--- a/__tests__/__snapshots__/getMatchStats.test.ts.snap
+++ b/__tests__/__snapshots__/getMatchStats.test.ts.snap
@@ -450,8 +450,8 @@ Object {
       "value": 19,
     },
     "mostAssists": Object {
-      "id": 8601,
-      "name": "zhokiNg",
+      "id": 10774,
+      "name": "Freeman",
       "value": 10,
     },
     "mostDamage": Object {
@@ -543,7 +543,7 @@ Object {
         "id": 8950,
         "killDeathsDifference": 1,
         "kills": 35,
-        "name": "kaze",
+        "name": "Kaze",
         "rating": 0.93,
       },
     ],

--- a/__tests__/getEvent.test.ts
+++ b/__tests__/getEvent.test.ts
@@ -5,7 +5,7 @@ test('getEvent', async () => {
   expect(await HLTV.getEvent({ id: 3552 })).toMatchSnapshot()
   expect(await HLTV.getEvent({ id: 355 })).toMatchSnapshot()
   expect(await HLTV.getEvent({ id: 3005 })).toMatchSnapshot()
-})
   expect(await HLTV.getEvent({ id: 4356 })).toMatchSnapshot()
   expect(await HLTV.getEvent({ id: 4409 })).toMatchSnapshot()
   expect(await HLTV.getEvent({ id: 2870 })).toMatchSnapshot()
+})

--- a/__tests__/getEvent.test.ts
+++ b/__tests__/getEvent.test.ts
@@ -6,3 +6,6 @@ test('getEvent', async () => {
   expect(await HLTV.getEvent({ id: 355 })).toMatchSnapshot()
   expect(await HLTV.getEvent({ id: 3005 })).toMatchSnapshot()
 })
+  expect(await HLTV.getEvent({ id: 4356 })).toMatchSnapshot()
+  expect(await HLTV.getEvent({ id: 4409 })).toMatchSnapshot()
+  expect(await HLTV.getEvent({ id: 2870 })).toMatchSnapshot()

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -49,6 +49,16 @@ export const getEvent = (config: HLTVConfig) => async ({
     )
   }))
 
+  function findEventByName(eventName, relatedEvents) {
+    if(eventName == null || relatedEvents.length == 0) return eventName;
+    for(var event of relatedEvents) {
+      if(event.name == eventName) {
+        return event;
+      }
+    }
+    return eventName;
+  }
+
   const prizeDistribution = toArray($('.placement')).map(placementEl => ({
     place: $(placementEl.children().get(1)).text(),
     prize:
@@ -56,6 +66,12 @@ export const getEvent = (config: HLTVConfig) => async ({
         .find('.prizeMoney')
         .first()
         .text() || undefined,
+    qualifiesFor:
+      findEventByName(placementEl
+        .find('.prizeMoney')
+        .first()
+        .next()
+        .text() || undefined, relatedEvents),
     team:
       placementEl.find('.team').children().length !== 0
         ? {

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -52,11 +52,8 @@ export const getEvent = (config: HLTVConfig) => async ({
 
   function findEventByName(eventName, relatedEvents): Event | undefined {
     if (eventName == null) return undefined
-    for (var event of relatedEvents) {
-      if (event.name == eventName) {
-        return event
-      }
-    }
+    const event = relatedEvents.find(event => event.name === eventName)
+    if (event) return event
     return { name: eventName }
   }
 

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -50,11 +50,11 @@ export const getEvent = (config: HLTVConfig) => async ({
     )
   }))
 
-  function findEventByName(eventName:string | undefined, relatedEvents:Event[]): Event | undefined {
+  function findEventByName(eventName:string | undefined, relatedEvents:Event[]): Event | string | undefined {
     if (eventName == null) return undefined
     const event = relatedEvents.find(event => event.name === eventName)
     if (event) return event
-    return { name: eventName }
+    return eventName
   }
 
   const prizeDistribution = toArray($('.placement')).map(placementEl => ({

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -50,13 +50,13 @@ export const getEvent = (config: HLTVConfig) => async ({
   }))
 
   function findEventByName(eventName, relatedEvents) {
-    if(eventName == null || relatedEvents.length == 0) return eventName;
-    for(var event of relatedEvents) {
-      if(event.name == eventName) {
-        return event;
+    if (eventName == null || relatedEvents.length == 0) return eventName
+    for (var event of relatedEvents) {
+      if (event.name == eventName) {
+        return event
       }
     }
-    return eventName;
+    return eventName
   }
 
   const prizeDistribution = toArray($('.placement')).map(placementEl => ({
@@ -66,12 +66,14 @@ export const getEvent = (config: HLTVConfig) => async ({
         .find('.prizeMoney')
         .first()
         .text() || undefined,
-    qualifiesFor:
-      findEventByName(placementEl
+    qualifiesFor: findEventByName(
+      placementEl
         .find('.prizeMoney')
         .first()
         .next()
-        .text() || undefined, relatedEvents),
+        .text() || undefined,
+      relatedEvents
+    ),
     team:
       placementEl.find('.team').children().length !== 0
         ? {

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -39,6 +39,16 @@ export const getEvent = (config: HLTVConfig) => async ({
         .trim() || undefined
   }))
 
+  const relatedEvents = toArray($('.related-event')).map(eventEl => ({
+    name: eventEl.find('.event-name').text(),
+    id: Number(
+      eventEl
+        .find('a')
+        .attr('href')
+        .split('/')[2]
+    )
+  }))
+
   const prizeDistribution = toArray($('.placement')).map(placementEl => ({
     place: $(placementEl.children().get(1)).text(),
     prize:
@@ -68,16 +78,6 @@ export const getEvent = (config: HLTVConfig) => async ({
       .split('\n')
       .join(' ')
       .trim()
-  }))
-
-  const relatedEvents = toArray($('.related-event')).map(eventEl => ({
-    name: eventEl.find('.event-name').text(),
-    id: Number(
-      eventEl
-        .find('a')
-        .attr('href')
-        .split('/')[2]
-    )
   }))
 
   const mapPool = toArray($('.map-pool-map-holder')).map(mapEl =>

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -50,7 +50,7 @@ export const getEvent = (config: HLTVConfig) => async ({
     )
   }))
 
-  function findEventByName(eventName, relatedEvents): Event | undefined {
+  function findEventByName(eventName:string | undefined, relatedEvents:Event[]): Event | undefined {
     if (eventName == null) return undefined
     const event = relatedEvents.find(event => event.name === eventName)
     if (event) return event

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -50,11 +50,11 @@ export const getEvent = (config: HLTVConfig) => async ({
     )
   }))
 
-  function findEventByName(eventName:string | undefined, relatedEvents:Event[]): Event | string | undefined {
+  function findEventByName(eventName:string | undefined, relatedEvents:Event[]): Event | undefined {
     if (eventName == null) return undefined
     const event = relatedEvents.find(event => event.name === eventName)
     if (event) return event
-    return eventName
+    return undefined
   }
 
   const prizeDistribution = toArray($('.placement')).map(placementEl => ({
@@ -72,6 +72,11 @@ export const getEvent = (config: HLTVConfig) => async ({
         .text() || undefined,
       relatedEvents
     ),
+    otherPrize:
+      !findEventByName(placementEl.find('.prizeMoney').first().next().text() || undefined, relatedEvents)
+        ? placementEl.find('.prizeMoney').first().next().text() || undefined
+        : undefined
+    ,
     team:
       placementEl.find('.team').children().length !== 0
         ? {

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -1,3 +1,4 @@
+import { Event } from '../models/Event'
 import { FullEvent } from '../models/FullEvent'
 import { HLTVConfig } from '../config'
 import { fetchPage, toArray, getMapSlug } from '../utils/mappers'
@@ -49,14 +50,14 @@ export const getEvent = (config: HLTVConfig) => async ({
     )
   }))
 
-  function findEventByName(eventName, relatedEvents) {
-    if (eventName == null || relatedEvents.length == 0) return eventName
+  function findEventByName(eventName, relatedEvents) : Event | undefined {
+    if (eventName == null) return undefined;
     for (var event of relatedEvents) {
       if (event.name == eventName) {
         return event
       }
     }
-    return eventName
+    return { name: eventName }
   }
 
   const prizeDistribution = toArray($('.placement')).map(placementEl => ({

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -50,7 +50,10 @@ export const getEvent = (config: HLTVConfig) => async ({
     )
   }))
 
-  function findEventByName(eventName:string | undefined, relatedEvents:Event[]): Event | undefined {
+  function findEventByName(
+    eventName: string | undefined,
+    relatedEvents: Event[]
+  ): Event | undefined {
     if (eventName == null) return undefined
     const event = relatedEvents.find(event => event.name === eventName)
     if (event) return event
@@ -72,11 +75,20 @@ export const getEvent = (config: HLTVConfig) => async ({
         .text() || undefined,
       relatedEvents
     ),
-    otherPrize:
-      !findEventByName(placementEl.find('.prizeMoney').first().next().text() || undefined, relatedEvents)
-        ? placementEl.find('.prizeMoney').first().next().text() || undefined
-        : undefined
-    ,
+    otherPrize: !findEventByName(
+      placementEl
+        .find('.prizeMoney')
+        .first()
+        .next()
+        .text() || undefined,
+      relatedEvents
+    )
+      ? placementEl
+          .find('.prizeMoney')
+          .first()
+          .next()
+          .text() || undefined
+      : undefined,
     team:
       placementEl.find('.team').children().length !== 0
         ? {

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -50,8 +50,8 @@ export const getEvent = (config: HLTVConfig) => async ({
     )
   }))
 
-  function findEventByName(eventName, relatedEvents) : Event | undefined {
-    if (eventName == null) return undefined;
+  function findEventByName(eventName, relatedEvents): Event | undefined {
+    if (eventName == null) return undefined
     for (var event of relatedEvents) {
       if (event.name == eventName) {
         return event

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -60,48 +60,39 @@ export const getEvent = (config: HLTVConfig) => async ({
     return undefined
   }
 
-  const prizeDistribution = toArray($('.placement')).map(placementEl => ({
-    place: $(placementEl.children().get(1)).text(),
-    prize:
-      placementEl
-        .find('.prizeMoney')
-        .first()
-        .text() || undefined,
-    qualifiesFor: findEventByName(
+  const prizeDistribution = toArray($('.placement')).map(placementEl => {
+    const otherPrize =
       placementEl
         .find('.prizeMoney')
         .first()
         .next()
-        .text() || undefined,
-      relatedEvents
-    ),
-    otherPrize: !findEventByName(
-      placementEl
-        .find('.prizeMoney')
-        .first()
-        .next()
-        .text() || undefined,
-      relatedEvents
-    )
-      ? placementEl
+        .text() || undefined
+
+    const qualifiesFor = !!otherPrize ? findEventByName(otherPrize, relatedEvents) : undefined
+
+    return {
+      place: $(placementEl.children().get(1)).text(),
+      prize:
+        placementEl
           .find('.prizeMoney')
           .first()
-          .next()
-          .text() || undefined
-      : undefined,
-    team:
-      placementEl.find('.team').children().length !== 0
-        ? {
-            name: placementEl.find('.team a').text(),
-            id: Number(
-              placementEl
-                .find('.team a')
-                .attr('href')
-                .split('/')[2]
-            )
-          }
-        : undefined
-  }))
+          .text() || undefined,
+      qualifiesFor: qualifiesFor,
+      otherPrize: !qualifiesFor ? otherPrize : undefined,
+      team:
+        placementEl.find('.team').children().length !== 0
+          ? {
+              name: placementEl.find('.team a').text(),
+              id: Number(
+                placementEl
+                  .find('.team a')
+                  .attr('href')
+                  .split('/')[2]
+              )
+            }
+          : undefined
+    }
+  })
 
   const formats = toArray($('.formats tr')).map(formatEl => ({
     type: formatEl.find('.format-header').text(),

--- a/src/models/FullEvent.ts
+++ b/src/models/FullEvent.ts
@@ -6,7 +6,8 @@ import { Country } from './Country'
 export interface EventPrizeDistribution {
   place: string
   prize?: string
-  qualifiesFor?: Event | string
+  otherPrize?: string
+  qualifiesFor?: Event
   team?: Team
 }
 

--- a/src/models/FullEvent.ts
+++ b/src/models/FullEvent.ts
@@ -6,7 +6,7 @@ import { Country } from './Country'
 export interface EventPrizeDistribution {
   place: string
   prize?: string
-  qualifiesFor?: Event
+  qualifiesFor?: Event | string
   team?: Team
 }
 

--- a/src/models/FullEvent.ts
+++ b/src/models/FullEvent.ts
@@ -6,6 +6,7 @@ import { Country } from './Country'
 export interface EventPrizeDistribution {
   place: string
   prize?: string
+  qualifiesFor?: Event
   team?: Team
 }
 


### PR DESCRIPTION
1. Adds `qualifiesFor:Event` to `EventPrizeDistribution`.
2. If a prize qualifies for an event, it will add it ( without `id` )
3. It will try to match it with events from relatedEvents array ( with `id` )
