### PR TITLE
Adding getEventStats endpoint and adding global stats id

### DIFF
--- a/src/endpoints/getEventStats.ts
+++ b/src/endpoints/getEventStats.ts
@@ -1,0 +1,126 @@
+import { UpcomingMatch } from '../models/UpcomingMatch'
+import { LiveMatch } from '../models/LiveMatch'
+import { Event } from '../models/Event'
+import { Team } from '../models/Team'
+import { MapSlug } from '../enums/MapSlug'
+import { popSlashSource, text } from '../utils/parsing'
+import { HLTVConfig } from '../config'
+import { fetchPage, toArray, getMatchFormatAndMap } from '../utils/mappers'
+import { MatchResult } from '../models/MatchResult'
+
+export const getEventStats = (config: HLTVConfig) => async ({ eventId }) => {
+  let $ = await fetchPage(`${config.hltvUrl}/matches?event=${eventId}`, config.loadPage)
+
+  const liveMatches: LiveMatch[] = toArray($('.live-match .a-reset')).map(matchEl => {
+    const id = Number(matchEl.attr('href').split('/')[2])
+    const teamEls = matchEl.find('img.logo')
+    const stars = matchEl.find('.stars i').length
+
+    const team1: Team = {
+      name: teamEls.first().attr('title'),
+      id: Number(popSlashSource(teamEls.first())) || undefined
+    }
+
+    const team2: Team = {
+      name: teamEls.last().attr('title'),
+      id: Number(popSlashSource(teamEls.last())) || undefined
+    }
+
+    const format = matchEl.find('.bestof').text()
+    const maps = toArray(matchEl.find('.header .map')).map(text) as MapSlug[]
+
+    const event: Event = {
+      name: matchEl.find('.event-logo').attr('title'),
+      id: Number((popSlashSource(matchEl.find('.event-logo')) as string).split('.')[0]) || undefined
+    }
+
+    return { id, team1, team2, event, format, maps, stars, live: true }
+  })
+
+  const upcomingMatches: UpcomingMatch[] = toArray($('.upcoming-match')).map(matchEl => {
+    const id = Number(matchEl.attr('href').split('/')[2])
+    const date = Number(matchEl.find('div.time').attr('data-unix')) || undefined
+    const title = matchEl.find('.placeholder-text-cell').text() || undefined
+    const stars = matchEl.find('.stars i').length
+
+    const { map, format } = getMatchFormatAndMap(matchEl.find('.map-text').text())
+
+    let event: Event | undefined
+    let team1: Team | undefined
+    let team2: Team | undefined
+
+    if (!title) {
+      team1 = {
+        name: matchEl
+          .find('div.team')
+          .first()
+          .text(),
+        id: Number(popSlashSource(matchEl.find('img.logo').first())) || undefined
+      }
+
+      team2 = {
+        name: matchEl
+          .find('div.team')
+          .last()
+          .text(),
+        id: matchEl.find('img.logo').get(1)
+          ? Number(popSlashSource($(matchEl.find('img.logo').last())))
+          : undefined
+      }
+      event = {
+        name: matchEl.find('.event-logo').attr('alt'),
+        id:
+          Number((popSlashSource(matchEl.find('img.event-logo')) as string).split('.')[0]) ||
+          undefined
+      }
+    }
+
+    return { id, date, team1, team2, format, map, title, event, stars, live: false }
+  })
+
+  $ = await fetchPage(`${config.hltvUrl}/results?event=${eventId}`, config.loadPage)
+
+  let results = [] as MatchResult[];
+
+  results = results.concat(
+    toArray($('.results-holder > .results-all > .results-sublist .result-con .a-reset')).map(
+      matchEl => {
+        const id = Number(matchEl.attr('href').split('/')[2])
+        const stars = matchEl.find('.stars i').length
+
+        const team1: Team = {
+          id: Number(popSlashSource(matchEl.find('img.team-logo').first())),
+          name: matchEl
+            .find('div.team')
+            .first()
+            .text()
+        }
+
+        const team2: Team = {
+          id: Number(popSlashSource(matchEl.find('img.team-logo').last())),
+          name: matchEl
+            .find('div.team')
+            .last()
+            .text()
+        }
+
+        const result = matchEl.find('.result-score').text()
+        const { map, format } = getMatchFormatAndMap(matchEl.find('.map-text').text()) as {
+          map: MapSlug | undefined
+          format: string
+        }
+
+        const event: Event = {
+          name: matchEl.find('.event-logo').attr('alt'),
+          id: 3448
+        }
+
+        const date = Number(matchEl.parent().attr('data-zonedgrouping-entry-unix'))
+
+        return { id, team1, team2, result, event, map, format, stars, date }
+      }
+    )
+  )
+
+  return {matches: [...liveMatches, ...upcomingMatches], results: results}
+}

--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -114,6 +114,15 @@ export const getMatch = (config: HLTVConfig) => async ({
       : undefined
   }))
 
+
+  maps.push({
+    // @ts-ignore
+    name: "All maps",
+    result: '-',
+    statsId: Number($('.stats-detailed-stats').find('a').attr('href').split('/')[3])
+  })
+
+
   let players: { team1: Player[]; team2: Player[] } | undefined
 
   if (team1 && team2) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { getTeam } from './endpoints/getTeam'
 import { getTeamStats } from './endpoints/getTeamStats'
 import { getPlayer } from './endpoints/getPlayer'
 import { getEvent } from './endpoints/getEvent'
+import { getEventStats } from './endpoints/getEventStats'
 import { getPlayerStats } from './endpoints/getPlayerStats'
 import { getPlayerRanking } from './endpoints/getPlayerRanking'
 
@@ -33,6 +34,7 @@ export class HLTVFactory {
   getTeamStats = getTeamStats(this.config)
   getPlayer = getPlayer(this.config)
   getEvent = getEvent(this.config)
+  getEventStats = getEventStats(this.config)
   getPlayerStats = getPlayerStats(this.config)
   getPlayerRanking = getPlayerRanking(this.config)
 

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -24,3 +24,4 @@
 // HLTV.getTeamStats({id: 6669}).then(res => console.dir(res, { depth: null })).catch(err => console.log(err))
 // HLTV.getPlayer({id: 9216}).then(res => console.dir(res, { depth: null })).catch(err => console.log(err))
 // HLTV.getEvent({id: 3773}).then(res => console.dir(res, { depth: null })).catch(err => console.log(err))
+// HLTV.getEventStats({id: 3773}).then(res => console.dir(res, { depth: null })).catch(err => console.log(err))


### PR DESCRIPTION
The new endpoint of getEventStats would provide the same as getMatches and getResults but joined and filtered by the eventId.

So it returns all the matches (upcoming, live) and results.

Also, I've added the global stats id for the matches, so we can take a look at the global stats for a match in getMatchStats.