### PR TITLE
Small improvements

### DIFF
--- a/__tests__/getEvent.test.ts
+++ b/__tests__/getEvent.test.ts
@@ -8,4 +8,4 @@ test('getEvent', async () => {
   expect(await HLTV.getEvent({ id: 4356 })).toMatchSnapshot()
   expect(await HLTV.getEvent({ id: 4409 })).toMatchSnapshot()
   expect(await HLTV.getEvent({ id: 2870 })).toMatchSnapshot()
-})
+}, 30000)

--- a/__tests__/getMatch.test.ts
+++ b/__tests__/getMatch.test.ts
@@ -5,4 +5,4 @@ test('getMatch', async () => {
   expect(await HLTV.getMatch({ id: 2302345 })).toMatchSnapshot()
   expect(await HLTV.getMatch({ id: 2290099 })).toMatchSnapshot()
   expect(await HLTV.getMatch({ id: 2186795 })).toMatchSnapshot()
-})
+}, 30000)

--- a/__tests__/getMatchStats.test.ts
+++ b/__tests__/getMatchStats.test.ts
@@ -4,4 +4,4 @@ test('getMatchStats', async () => {
   expect(await HLTV.getMatchStats({ id: 62979 })).toMatchSnapshot()
   expect(await HLTV.getMatchStats({ id: 63146 })).toMatchSnapshot()
   expect(await HLTV.getMatchStats({ id: 63095 })).toMatchSnapshot()
-})
+}, 30000)

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export interface HLTVConfig {
 }
 
 export const defaultConfig = {
-  hltvUrl: 'http://www.hltv.org',
+  hltvUrl: 'https://www.hltv.org',
   hltvStaticUrl: 'https://static.hltv.org',
   loadPage: defaultLoadPage
 }

--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -1,4 +1,3 @@
-import { Event } from '../models/Event'
 import { FullEvent } from '../models/FullEvent'
 import { HLTVConfig } from '../config'
 import { fetchPage, toArray, getMapSlug } from '../utils/mappers'
@@ -50,16 +49,6 @@ export const getEvent = (config: HLTVConfig) => async ({
     )
   }))
 
-  function findEventByName(
-    eventName: string | undefined,
-    relatedEvents: Event[]
-  ): Event | undefined {
-    if (eventName == null) return undefined
-    const event = relatedEvents.find(event => event.name === eventName)
-    if (event) return event
-    return undefined
-  }
-
   const prizeDistribution = toArray($('.placement')).map(placementEl => {
     const otherPrize =
       placementEl
@@ -68,7 +57,9 @@ export const getEvent = (config: HLTVConfig) => async ({
         .next()
         .text() || undefined
 
-    const qualifiesFor = !!otherPrize ? findEventByName(otherPrize, relatedEvents) : undefined
+    const qualifiesFor = !!otherPrize
+      ? relatedEvents.find(event => event.name === otherPrize)
+      : undefined
 
     return {
       place: $(placementEl.children().get(1)).text(),

--- a/src/utils/mappers.ts
+++ b/src/utils/mappers.ts
@@ -10,7 +10,7 @@ import { popSlashSource } from '../utils/parsing'
 
 export const defaultLoadPage = (url: string) =>
   new Promise<string>(resolve => {
-    request.get(url, (_, __, body) => resolve(body))
+    request.get(url, { gzip: true }, (_, __, body) => resolve(body))
   })
 
 export const fetchPage = async (


### PR DESCRIPTION
1. Addresses the last comment from the previous PR #122  ( removes `findEventByName` and replaces it with `relatedEvents.find` instead )
2. Enable `gzip` compression by default - which results in smaller transferred filesize per request.
3. Increase testing time for people on slower connections. Currently tests take here around 8-12 seconds, which times out the jest default of 5 seconds ( `Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.` ). Increased the time for each test to 30 seconds. This shouldn't have any effect on people with faster connections.
4. Currently every request is being 301 redirected from `http` -> `https`. Changing the default url fixes it.