### PR TITLE
Add more options to getPlayerRanking

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Option | Type | Default value | Description |
 :---:|:---:|:---:|:---:|
 startDate | string | - | - |
 endDate | string | - | - |
+matchType | string | - | - |
+rankingFilter | string | - | - |
 
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -304,8 +304,8 @@ Option | Type | Default value | Description |
 :---:|:---:|:---:|:---:|
 startDate | string | - | - |
 endDate | string | - | - |
-matchType | string | - | - |
-rankingFilter | string | - | - |
+matchType | [MatchType](https://github.com/gigobyte/HLTV/blob/master/src/enums/MatchType.ts)? | - | - |
+rankingFilter | [RankingFilter](https://github.com/gigobyte/HLTV/blob/master/src/enums/RankingFilter.ts)? | - | - |
 
 
 ```javascript

--- a/src/endpoints/getPlayerRanking.ts
+++ b/src/endpoints/getPlayerRanking.ts
@@ -1,18 +1,27 @@
+import querystring from 'querystring';
 import { PlayerRanking } from '../models/PlayerRanking'
 import { HLTVConfig } from '../config'
 import { fetchPage, toArray } from '../utils/mappers'
 
 export const getPlayerRanking = (config: HLTVConfig) => async ({
   startDate,
-  endDate
+  endDate,
+  matchType,
+  rankingFilter
 }: {
   startDate: string
   endDate: string
+  matchType: string
+  rankingFilter: string
 }): Promise<PlayerRanking[]> => {
-  const options =
-    startDate != null && endDate != null ? '?startDate=' + startDate + '&endDate=' + endDate : ''
+  const query = querystring.stringify({
+    startDate,
+    endDate,
+    matchType,
+    rankingFilter
+  })
 
-  const $ = await fetchPage(`${config.hltvUrl}/stats/players${options}`, config.loadPage)
+  const $ = await fetchPage(`${config.hltvUrl}/stats/players?${query}`, config.loadPage)
 
   const players = toArray($('.player-ratings-table tbody tr')).map(matchEl => {
     var id = Number(

--- a/src/endpoints/getPlayerRanking.ts
+++ b/src/endpoints/getPlayerRanking.ts
@@ -1,5 +1,7 @@
 import querystring from 'querystring';
 import { PlayerRanking } from '../models/PlayerRanking'
+import { MatchType } from '../enums/MatchType'
+import { RankingFilter } from '../enums/RankingFilter'
 import { HLTVConfig } from '../config'
 import { fetchPage, toArray } from '../utils/mappers'
 
@@ -11,8 +13,8 @@ export const getPlayerRanking = (config: HLTVConfig) => async ({
 }: {
   startDate: string
   endDate: string
-  matchType: string
-  rankingFilter: string
+  matchType: MatchType
+  rankingFilter: RankingFilter
 }): Promise<PlayerRanking[]> => {
   const query = querystring.stringify({
     startDate,

--- a/src/enums/RankingFilter.ts
+++ b/src/enums/RankingFilter.ts
@@ -1,7 +1,7 @@
 export const enum RankingFilter {
-  'Top 5' = 'Top5',
-  'Top 10' = 'Top10',
-  'Top 20' = 'Top20',
-  'Top 30' = 'Top30',
-  'Top 50' = 'Top50'
+  Top5 = 'Top5',
+  Top10 = 'Top10',
+  Top20 = 'Top20',
+  Top30 = 'Top30',
+  Top50 = 'Top50'
 }

--- a/src/enums/RankingFilter.ts
+++ b/src/enums/RankingFilter.ts
@@ -1,0 +1,7 @@
+export const enum RankingFilter {
+  'Top 5' = 'Top5',
+  'Top 10' = 'Top10',
+  'Top 20' = 'Top20',
+  'Top 30' = 'Top30',
+  'Top 50' = 'Top50'
+}


### PR DESCRIPTION
This branch adds `matchType` and `rankingFilter` options to the `getPlayerRanking` endpoint. This is really useful, since they are required to get more refined ranking lists. For example, top 50 at majors for all time: https://www.hltv.org/stats/players?matchType=Majors&rankingFilter=Top50

I used the Node `querystring` module to stringify any/all of the options provided, so the only "breaking" change would be that now you can set _only_ an end or start date, rather than requiring both to be set.