### PR TITLE
Return id with data requested by id

### DIFF
--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -100,6 +100,7 @@ export const getEvent = (config: HLTVConfig) => async ({
   )
 
   return {
+    id,
     name,
     dateStart,
     dateEnd,

--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -234,6 +234,7 @@ export const getMatch = (config: HLTVConfig) => async ({
   }
 
   return {
+    id,
     team1,
     team2,
     winnerTeam,

--- a/src/endpoints/getPlayer.ts
+++ b/src/endpoints/getPlayer.ts
@@ -125,6 +125,7 @@ export const getPlayer = (config: HLTVConfig) => async ({
   }))
 
   return {
+    id,
     name,
     ign,
     image,

--- a/src/endpoints/getTeam.ts
+++ b/src/endpoints/getTeam.ts
@@ -114,6 +114,7 @@ export const getTeam = (config: HLTVConfig) => async ({
     )
 
   return {
+    id,
     name,
     logo,
     coverImage,

--- a/src/models/FullEvent.ts
+++ b/src/models/FullEvent.ts
@@ -21,6 +21,7 @@ export interface EventFormat {
 }
 
 export interface FullEvent {
+  id: number
   name: string
   dateStart?: number
   dateEnd?: number

--- a/src/models/FullMatch.ts
+++ b/src/models/FullMatch.ts
@@ -9,6 +9,7 @@ import { Veto } from './Veto'
 import { Highlight } from './Highlight'
 
 export interface FullMatch {
+  readonly id: number
   readonly team1?: Team
   readonly team2?: Team
   readonly winnerTeam?: Team

--- a/src/models/FullPlayer.ts
+++ b/src/models/FullPlayer.ts
@@ -3,6 +3,7 @@ import { Team } from './Team'
 import { Achievement } from './FullTeam'
 
 export interface FullPlayer {
+  readonly id: number
   readonly name?: string
   readonly ign: string
   readonly image?: string

--- a/src/models/FullTeam.ts
+++ b/src/models/FullTeam.ts
@@ -22,6 +22,7 @@ export interface MapStatistic {
 }
 
 export interface FullTeam {
+  readonly id: number
   readonly name: string
   readonly players: Player[]
   readonly logo: string


### PR DESCRIPTION
This branch adds an `id` value to the response of endpoints that return data based on an `id` option. Specifically, this affects `getEvent`, `getTeam`, `getMatch`, and `getPlayer` endpoints. This seems like a reasonable thing to expect from an API, but I'd be happy to hear your thoughts on the subject!

My use case: I'm creating an array of players by iterating over a team's members and getting the `FullPlayer` for each. I'm using React to render the players, and I want to use the player ID as the `key` prop. To satisfy this, my custom `getPlayers` function looks like this:

```js
function getPlayers(team) {
  return Promise.all(team.players.map(async ({id}) => {
    const player = await hltv.getPlayer({id});
    return {
      ...player,
      id
    };
  });
}
```

With this change, it would simplify this function to something like this:

```js
function getPlayers(team) {
  // much nicer 😄 
  return Promise.all(team.players.map(player => hltv.getPlayer({id: player.id})));
}
```