### PR TITLE
Fix build error

### DIFF
--- a/__tests__/__snapshots__/getEvent.test.ts.snap
+++ b/__tests__/__snapshots__/getEvent.test.ts.snap
@@ -10,6 +10,7 @@ Object {
       "type": "Playoffs",
     },
   ],
+  "id": 3452,
   "location": Object {
     "code": "SE",
     "name": "Sweden",
@@ -107,6 +108,7 @@ Object {
       "type": "Playoffs",
     },
   ],
+  "id": 3552,
   "location": Object {
     "code": "EU",
     "name": "Europe",
@@ -294,6 +296,7 @@ Object {
   "dateEnd": undefined,
   "dateStart": undefined,
   "formats": Array [],
+  "id": 355,
   "location": Object {
     "code": "WORLD",
     "name": "World",
@@ -323,6 +326,7 @@ Object {
   "dateEnd": 1500976800000,
   "dateStart": 1500285600000,
   "formats": Array [],
+  "id": 3005,
   "location": Object {
     "code": "AR",
     "name": "Argentina",
@@ -468,6 +472,7 @@ Object {
       "type": "Playoffs",
     },
   ],
+  "id": 4356,
   "location": Object {
     "code": "NAM",
     "name": "North America",
@@ -632,6 +637,7 @@ Object {
   "dateEnd": 1495360800000,
   "dateStart": 1495360800000,
   "formats": Array [],
+  "id": 2870,
   "location": Object {
     "code": "SE",
     "name": "Sweden",

--- a/__tests__/__snapshots__/getMatch.test.ts.snap
+++ b/__tests__/__snapshots__/getMatch.test.ts.snap
@@ -195,6 +195,7 @@ Object {
       "title": "MSL triple kill hold to earn map point (Mirage)",
     },
   ],
+  "id": 2325765,
   "live": false,
   "maps": Array [
     Object {
@@ -360,6 +361,7 @@ Object {
     "name": "JonY%20BoY",
   },
   "highlights": Array [],
+  "id": 2302345,
   "live": false,
   "maps": Array [
     Object {
@@ -456,6 +458,7 @@ Object {
   "headToHead": Array [],
   "highlightedPlayer": undefined,
   "highlights": Array [],
+  "id": 2290099,
   "live": false,
   "maps": Array [
     Object {
@@ -545,6 +548,7 @@ Object {
     "name": "fl0w",
   },
   "highlights": Array [],
+  "id": 2186795,
   "live": false,
   "maps": Array [
     Object {

--- a/src/endpoints/getPlayerRanking.ts
+++ b/src/endpoints/getPlayerRanking.ts
@@ -1,4 +1,4 @@
-import querystring from 'querystring';
+import { stringify } from 'querystring';
 import { PlayerRanking } from '../models/PlayerRanking'
 import { MatchType } from '../enums/MatchType'
 import { RankingFilter } from '../enums/RankingFilter'
@@ -16,7 +16,7 @@ export const getPlayerRanking = (config: HLTVConfig) => async ({
   matchType: MatchType
   rankingFilter: RankingFilter
 }): Promise<PlayerRanking[]> => {
-  const query = querystring.stringify({
+  const query = stringify({
     startDate,
     endDate,
     matchType,


### PR DESCRIPTION
This branch fixes an issue that I introduced in one of my earlier PRs 😇 

I originally noticed that the changes I made in those PRs weren't reflected in the files in the npm module. I see that the repo is using a `prepare` script in package.json that tests and builds the library every `npm publish`, so I thought that would be a good place to investigate first.

I tried running the tests and building the library on my own machine, and ran into a couple errors:

- The snapshots were out of date, since we're now adding the `id` property to all events and matches
- I was incorrectly importing the Node `querystring` module

To fix these issues, I regenerated the test snapshots by running `npm test -- -u`, and changed the `querystring` import like this:

```js
- import querystring from 'querystring';
+ import { stringify } from 'querystring';

const options = stringify({...}); // was querystring.stringify
```