### PR TITLE
Fixes teamless players

### DIFF
--- a/src/endpoints/getPlayer.ts
+++ b/src/endpoints/getPlayer.ts
@@ -81,9 +81,11 @@ export const getPlayer = (config: HLTVConfig) => async ({
     } else {
       const playerTeam = $('.playerTeam a')
       const playerHref = playerTeam.attr('href')
-      team = {
-        name: playerTeam.text().trim(),
-        id: playerHref ? Number(playerHref.split('/')[2]) : 0
+      if (playerHref) {
+        team = {
+          name: playerTeam.text().trim(),
+          id: Number(playerHref.split('/')[2])
+        }
       }
     }
   }

--- a/src/endpoints/getPlayer.ts
+++ b/src/endpoints/getPlayer.ts
@@ -67,27 +67,25 @@ export const getPlayer = (config: HLTVConfig) => async ({
       .text()
       .trim() !== '-'
   ) {
-    team = isStandardPlayer
-      ? {
-          name: $('.profile-player-stat-value a')
-            .text()
-            .trim(),
-          id: Number(
-            $('.profile-player-stat-value a')
-              .attr('href')
-              .split('/')[2]
-          )
-        }
-      : {
-          name: $('.playerTeam a')
-            .text()
-            .trim(),
-          id: Number(
-            $('.playerTeam a')
-              .attr('href')
-              .split('/')[2]
-          )
-        }
+    if (isStandardPlayer) {
+      team = {
+        name: $('.profile-player-stat-value a')
+          .text()
+          .trim(),
+        id: Number(
+          $('.profile-player-stat-value a')
+            .attr('href')
+            .split('/')[2]
+        )
+      }
+    } else {
+      const playerTeam = $('.playerTeam a')
+      const playerHref = playerTeam.attr('href')
+      team = {
+        name: playerTeam.text().trim(),
+        id: playerHref ? Number(playerHref.split('/')[2]) : 0
+      }
+    }
   }
 
   const getMapStat = i =>

--- a/src/endpoints/getPlayerRanking.ts
+++ b/src/endpoints/getPlayerRanking.ts
@@ -1,4 +1,4 @@
-import { stringify } from 'querystring';
+import { stringify } from 'querystring'
 import { PlayerRanking } from '../models/PlayerRanking'
 import { MatchType } from '../enums/MatchType'
 import { RankingFilter } from '../enums/RankingFilter'


### PR DESCRIPTION
This branch fixes an issue I was seeing when I would try to get a player by ID using `getPlayer`. If I tried to request a player that isn't currently on a team...

```js
const player = await HLTV.getPlayer({id: 2730}); // looking for ChrisJ 😢
```

I would get:

```
TypeError: Cannot read property 'split' of undefined
```

My program was hanging up on [this line](https://github.com/gigobyte/HLTV/blob/master/src/endpoints/getPlayer.ts#L88), where it tries to split the value of an `href` attribute that doesn't exist.

To fix this, I changed the ternary operator that sets the `team` property to a series of if/else blocks. If the `.playerTeam a` doesn't have an `href` (no team), then `team` is left undefined.