### PR TITLE
Fix spelling of "grenade"

### DIFF
--- a/src/endpoints/getPlayerStats.ts
+++ b/src/endpoints/getPlayerStats.ts
@@ -64,7 +64,7 @@ export const getPlayerStats = (config: HLTVConfig) => async ({
     deaths: getStats(2),
     kdRatio: getStats(3),
     damagePerRound: getStats(4),
-    granadeDamagePerRound: getStats(5),
+    grenadeDamagePerRound: getStats(5),
     mapsPlayed: getStats(6),
     roundsPlayed: getStats(7),
     killsPerRound: getStats(8),

--- a/src/models/FullPlayerStats.ts
+++ b/src/models/FullPlayerStats.ts
@@ -14,7 +14,7 @@ export interface FullPlayerStats {
     deaths: string
     kdRatio: string
     damagePerRound: string
-    granadeDamagePerRound: string
+    grenadeDamagePerRound: string
     mapsPlayed: string
     roundsPlayed: string
     killsPerRound: string


### PR DESCRIPTION
This branch fixes the spelling of "grenade" in the `grenadeDamagePerRound` statistic