### PR TITLE
Add more options to the getPlayerStats endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ Option | Type | Default value | Description |
 id | int | - | - |
 startDate | string | - | - |
 endDate | string | - | - |
+matchType | [MatchType](https://github.com/gigobyte/HLTV/blob/master/src/enums/MatchType.ts)? | - | - |
+rankingFilter | [RankingFilter](https://github.com/gigobyte/HLTV/blob/master/src/enums/RankingFilter.ts)? | - | - |
 
 ```javascript
 HLTV.getPlayerStats({id: 7998}).then(res => {

--- a/src/endpoints/getPlayerStats.ts
+++ b/src/endpoints/getPlayerStats.ts
@@ -1,23 +1,33 @@
 import { FullPlayerStats } from '../models/FullPlayerStats'
 import { Team } from '../models/Team'
+import { stringify } from 'querystring'
 import { HLTVConfig } from '../config'
+import { MatchType } from '../enums/MatchType'
+import { RankingFilter } from '../enums/RankingFilter'
 import { fetchPage } from '../utils/mappers'
 import { popSlashSource } from '../utils/parsing'
 
 export const getPlayerStats = (config: HLTVConfig) => async ({
   id,
   startDate,
-  endDate
+  endDate,
+  matchType,
+  rankingFilter
 }: {
   id: number
   startDate: string
   endDate: string
+  matchType: MatchType
+  rankingFilter: RankingFilter
 }): Promise<FullPlayerStats> => {
-  let options = ''
-  if (startDate != null && endDate != null) {
-    options = '?startDate=' + startDate + '&endDate=' + endDate
-  }
-  const $ = await fetchPage(`${config.hltvUrl}/stats/players/${id}/-${options}`, config.loadPage)
+  const query = stringify({
+    startDate,
+    endDate,
+    matchType,
+    rankingFilter
+  })
+
+  const $ = await fetchPage(`${config.hltvUrl}/stats/players/${id}/-?${query}`, config.loadPage)
 
   const name = $('.statsPlayerName').text() || undefined
   const ign = $('.context-item-name').text()


### PR DESCRIPTION
This branch adds `matchType` and `rankingFilter` options to the `getPlayerStats` endpoint, so that you can make queries like this: https://www.hltv.org/stats/players/7998/-?endDate=2019-02-24&matchType=Majors&rankingFilter=Top50

This would be really useful to be able to reproduce the same functionality available on the HLTV website!