### PR TITLE
Get event results

### DIFF
--- a/src/endpoints/getResults.ts
+++ b/src/endpoints/getResults.ts
@@ -23,17 +23,12 @@ export const getResults = (config: HLTVConfig) => async ({ pages = 1, eventId = 
 
   for (let i = 0; i < pages; i++) {
     let fullUrl = `${config.hltvUrl}/results?offset=${i * 100}`
-    let eventName: string
 
     if(eventId) {
       fullUrl += `&event=${eventId}`
     }
     
     const $ = await fetchPage(fullUrl, config.loadPage)
-
-    if(eventId) {
-      eventName = $('.eventname').text()
-    }
     
     matches = matches.concat(
       toArray($('.results-holder > .results-all > .results-sublist .result-con .a-reset')).map(
@@ -64,7 +59,7 @@ export const getResults = (config: HLTVConfig) => async ({ pages = 1, eventId = 
           }
 
           const event: Event = {
-            name: eventId ? eventName : matchEl.find('.event-logo').attr('alt'),
+            name: eventId ? $('.eventname').text() : matchEl.find('.event-logo').attr('alt'),
             id: eventId
               ? eventId
               : Number(popSlashSource(matchEl.find('.event-logo'))!.split('.')[0])

--- a/src/endpoints/getResults.ts
+++ b/src/endpoints/getResults.ts
@@ -6,16 +6,20 @@ import { popSlashSource } from '../utils/parsing'
 import { HLTVConfig } from '../config'
 import { fetchPage, toArray, getMatchFormatAndMap } from '../utils/mappers'
 
-export const getResults = (config: HLTVConfig) => async ({ pages = 1, eventId = 0 } = {}): Promise<
-  MatchResult[]
-> => {
+export const getResults = (config: HLTVConfig) => async ({
+  pages = 1,
+  eventId
+}: {
+  pages: number
+  eventId?: number
+}): Promise<MatchResult[]> => {
   if (pages < 1) {
     console.error('getLatestResults: pages cannot be less than 1')
     return []
   }
 
   // All results for events are always on one page
-  if(eventId) {
+  if (eventId) {
     pages = 1
   }
 
@@ -24,12 +28,12 @@ export const getResults = (config: HLTVConfig) => async ({ pages = 1, eventId = 
   for (let i = 0; i < pages; i++) {
     let fullUrl = `${config.hltvUrl}/results?offset=${i * 100}`
 
-    if(eventId) {
+    if (eventId) {
       fullUrl += `&event=${eventId}`
     }
-    
+
     const $ = await fetchPage(fullUrl, config.loadPage)
-    
+
     matches = matches.concat(
       toArray($('.results-holder > .results-all > .results-sublist .result-con .a-reset')).map(
         matchEl => {

--- a/src/endpoints/getResults.ts
+++ b/src/endpoints/getResults.ts
@@ -14,6 +14,11 @@ export const getResults = (config: HLTVConfig) => async ({ pages = 1, eventId = 
     return []
   }
 
+  // All results for events are always on one page
+  if(eventId) {
+    pages = 1
+  }
+
   let matches = [] as MatchResult[]
 
   for (let i = 0; i < pages; i++) {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -30,5 +30,5 @@ import HLTV from './index'
 // HLTV.getEvent({id: 3773}).then(res => console.dir(res, { depth: null })).catch(err => console.log(err))
 
 
-// HLTV.getResults({pages: 1}).then(res => console.log(res))
 HLTV.getResults({pages: 1, eventId: 3883}).then(res => console.log(res))
+HLTV.getResults({pages: 1, eventId: 3047}).then(res => console.log(3047 + ':' + res.length))

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,7 +1,7 @@
 import HLTV from './index'
-HLTV.getMatch({ id: 2332676 })
-  .then(res => console.dir(res, { depth: null }))
-  .catch(err => console.log(err))
+// HLTV.getMatch({ id: 2332676 })
+//   .then(res => console.dir(res, { depth: null }))
+//   .catch(err => console.log(err))
 // HLTV.getMatches().then(res => console.log(res))
 // HLTV.getResults({pages: 1}).then(res => console.log(res))
 // HLTV.getStreams({ loadLinks: true }).then(res => console.log(res))
@@ -28,3 +28,7 @@ HLTV.getMatch({ id: 2332676 })
 // HLTV.getTeamStats({id: 6669}).then(res => console.dir(res, { depth: null })).catch(err => console.log(err))
 // HLTV.getPlayer({id: 9216}).then(res => console.dir(res, { depth: null })).catch(err => console.log(err))
 // HLTV.getEvent({id: 3773}).then(res => console.dir(res, { depth: null })).catch(err => console.log(err))
+
+
+// HLTV.getResults({pages: 1}).then(res => console.log(res))
+HLTV.getResults({pages: 1, eventId: 3883}).then(res => console.log(res))


### PR DESCRIPTION
Simirally to filtering by `teamId`, I added a parameter for events. I also changed how the Event data is filled and how the date-time is found, because the results page of events has a bit different layout

I also reset the `pages `parameter to 1 if the `eventId` parameter is passed. That's because all the results for events are show on one page. For example: [event=3047](https://www.hltv.org/results?event=3047) has 220 results...
Maybe they have a limit of 500 or something, but I didn't find any events that have that many results :)

This PR is related to issue #124.

I did a new branch from `master`, so the `teamId` parameter is not included... But it should not be difficult to merge both.