### PR TITLE
Added match status

### DIFF
--- a/__tests__/__snapshots__/getMatch.test.ts.snap
+++ b/__tests__/__snapshots__/getMatch.test.ts.snap
@@ -262,6 +262,7 @@ Object {
       },
     ],
   },
+  "status": "Match over",
   "streams": Array [],
   "team1": Object {
     "id": 4494,
@@ -430,6 +431,7 @@ Object {
       },
     ],
   },
+  "status": "Match over",
   "streams": Array [],
   "team1": Object {
     "id": 6785,
@@ -519,6 +521,7 @@ Object {
       },
     ],
   },
+  "status": "Match over",
   "streams": Array [],
   "team1": Object {
     "id": 4494,
@@ -611,6 +614,7 @@ Object {
       },
     ],
   },
+  "status": "Match over",
   "streams": Array [],
   "team1": Object {
     "id": 4498,

--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -44,11 +44,11 @@ export const getMatch = (config: HLTVConfig) => async ({
     .trim()
 
   let status = MatchStatus.scheduled
-  if($('.countdown').text() === 'LIVE') {
-    status = MatchStatus.live
-  }
   if(!$('.countdown').attr('data-time-countdown')) {
     status = $('.countdown').text() as MatchStatus
+  }
+  else if($('.countdown').text() === MatchStatus.live) {
+    status = MatchStatus.live
   }
 
   const live = status === MatchStatus.live

--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -10,6 +10,7 @@ import { Highlight } from '../models/Highlight'
 import { Veto } from '../models/Veto'
 import { HeadToHeadResult } from '../models/HeadToHeadResult'
 import { MapSlug } from '../enums/MapSlug'
+import { MatchStatus } from '../enums/MatchStatus';
 import { popSlashSource, hasChild, hasNoChild, percentageToDecimalOdd } from '../utils/parsing'
 import { HLTVConfig } from '../config'
 import {
@@ -41,7 +42,24 @@ export const getMatch = (config: HLTVConfig) => async ({
     .slice(1)
     .join(' ')
     .trim()
-  const live = $('.countdown').text() === 'LIVE'
+
+  let status = MatchStatus.upcoming
+
+  switch ($('.countdown').text()) {
+    case MatchStatus.live:
+      status = MatchStatus.live
+      break
+    case MatchStatus.over:
+      status = MatchStatus.over
+      break
+    case MatchStatus.postponed:
+      status = MatchStatus.postponed
+      break
+    default:
+      break
+  }
+
+  const live = status === MatchStatus.live
   const hasScorebot = $('#scoreboardElement').length !== 0
   const teamEls = $('div.teamName')
 
@@ -318,6 +336,7 @@ export const getMatch = (config: HLTVConfig) => async ({
     players,
     streams,
     live,
+    status,
     title,
     hasScorebot,
     highlightedPlayer,

--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -43,20 +43,12 @@ export const getMatch = (config: HLTVConfig) => async ({
     .join(' ')
     .trim()
 
-  let status = MatchStatus.upcoming
-
-  switch ($('.countdown').text()) {
-    case MatchStatus.live:
-      status = MatchStatus.live
-      break
-    case MatchStatus.over:
-      status = MatchStatus.over
-      break
-    case MatchStatus.postponed:
-      status = MatchStatus.postponed
-      break
-    default:
-      break
+  let status = MatchStatus.scheduled
+  if($('.countdown').text() === 'LIVE') {
+    status = MatchStatus.live
+  }
+  if(!$('.countdown').attr('data-time-countdown')) {
+    status = $('.countdown').text() as MatchStatus
   }
 
   const live = status === MatchStatus.live

--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -43,15 +43,15 @@ export const getMatch = (config: HLTVConfig) => async ({
     .join(' ')
     .trim()
 
-  let status = MatchStatus.scheduled
+  let status = MatchStatus.Scheduled
   if(!$('.countdown').attr('data-time-countdown')) {
     status = $('.countdown').text() as MatchStatus
   }
-  else if($('.countdown').text() === MatchStatus.live) {
-    status = MatchStatus.live
+  else if($('.countdown').text() === MatchStatus.Live) {
+    status = MatchStatus.Live
   }
 
-  const live = status === MatchStatus.live
+  const live = status === MatchStatus.Live
   const hasScorebot = $('#scoreboardElement').length !== 0
   const teamEls = $('div.teamName')
 

--- a/src/enums/MatchStatus.ts
+++ b/src/enums/MatchStatus.ts
@@ -1,0 +1,6 @@
+export enum MatchStatus {
+  live = 'LIVE',
+  postponed = 'Match postponed',
+  over = 'Match over',
+  upcoming = 'Upcoming'
+}

--- a/src/enums/MatchStatus.ts
+++ b/src/enums/MatchStatus.ts
@@ -2,5 +2,5 @@ export enum MatchStatus {
   live = 'LIVE',
   postponed = 'Match postponed',
   over = 'Match over',
-  upcoming = 'Upcoming'
+  scheduled = 'Scheduled'
 }

--- a/src/enums/MatchStatus.ts
+++ b/src/enums/MatchStatus.ts
@@ -1,6 +1,6 @@
 export enum MatchStatus {
-  live = 'LIVE',
-  postponed = 'Match postponed',
-  over = 'Match over',
-  scheduled = 'Scheduled'
+  Live = 'LIVE',
+  Postponed = 'Match postponed',
+  Over = 'Match over',
+  Scheduled = 'Scheduled'
 }

--- a/src/models/FullMatch.ts
+++ b/src/models/FullMatch.ts
@@ -1,3 +1,4 @@
+import { MatchStatus } from './../enums/MatchStatus';
 import { Team } from './Team'
 import { Event } from './Event'
 import { MapResult } from './MapResult'
@@ -28,6 +29,7 @@ export interface FullMatch {
   }
   readonly title?: string
   readonly live: boolean
+  readonly status: MatchStatus
   readonly hasScorebot: boolean
   readonly highlightedPlayer?: Player
   readonly headToHead?: HeadToHeadResult[]

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -19,7 +19,7 @@ import HLTV from './index'
 //     console.dir(data, { depth: null })
 // }})
 // HLTV.getMatchesStats({startDate: '2017-07-10', endDate: '2017-07-18'}).then(res => console.log(res.length))
-HLTV.getMatch({id: 2333372}).then(res => console.dir(res, {depth: null})).catch(err => console.log(err))
+HLTV.getMatch({id: 2333283}).then(res => console.dir(res, {depth: null})).catch(err => console.log(err))
 // HLTV.getMatchMapStats({id: 49968}).then(res => console.dir(res, { depth: null }))
 // HLTV.getMatchStats({id: 62979}).then(res => console.dir(res, { depth: null }))
 // HLTV.getTeam({ id: 9481 })

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -19,7 +19,7 @@ import HLTV from './index'
 //     console.dir(data, { depth: null })
 // }})
 // HLTV.getMatchesStats({startDate: '2017-07-10', endDate: '2017-07-18'}).then(res => console.log(res.length))
-HLTV.getMatch({id: 2332985}).then(res => console.dir(res, {depth: null})).catch(err => console.log(err))
+// HLTV.getMatch({id: 2312432}).then(res => console.dir(res, {depth: null})).catch(err => console.log(err))
 // HLTV.getMatchMapStats({id: 49968}).then(res => console.dir(res, { depth: null }))
 // HLTV.getMatchStats({id: 62979}).then(res => console.dir(res, { depth: null }))
 // HLTV.getTeam({ id: 9481 })
@@ -30,5 +30,5 @@ HLTV.getMatch({id: 2332985}).then(res => console.dir(res, {depth: null})).catch(
 // HLTV.getEvent({id: 3773}).then(res => console.dir(res, { depth: null })).catch(err => console.log(err))
 
 
-// HLTV.getResults({pages: 1, eventId: 3883}).then(res => console.log(res))
-// HLTV.getResults({pages: 1, eventId: 3047}).then(res => console.log(3047 + ':' + res.length))
+HLTV.getResults({pages: 1, eventId: 3883}).then(res => console.log(res))
+HLTV.getResults({pages: 1, eventId: 3047}).then(res => console.log(3047 + ':' + res.length))

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -19,7 +19,7 @@ import HLTV from './index'
 //     console.dir(data, { depth: null })
 // }})
 // HLTV.getMatchesStats({startDate: '2017-07-10', endDate: '2017-07-18'}).then(res => console.log(res.length))
-HLTV.getMatch({id: 2333283}).then(res => console.dir(res, {depth: null})).catch(err => console.log(err))
+HLTV.getMatch({id: 2332985}).then(res => console.dir(res, {depth: null})).catch(err => console.log(err))
 // HLTV.getMatchMapStats({id: 49968}).then(res => console.dir(res, { depth: null }))
 // HLTV.getMatchStats({id: 62979}).then(res => console.dir(res, { depth: null }))
 // HLTV.getTeam({ id: 9481 })

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -19,7 +19,7 @@ import HLTV from './index'
 //     console.dir(data, { depth: null })
 // }})
 // HLTV.getMatchesStats({startDate: '2017-07-10', endDate: '2017-07-18'}).then(res => console.log(res.length))
-// HLTV.getMatch({id: 2312432}).then(res => console.dir(res, {depth: null})).catch(err => console.log(err))
+HLTV.getMatch({id: 2333372}).then(res => console.dir(res, {depth: null})).catch(err => console.log(err))
 // HLTV.getMatchMapStats({id: 49968}).then(res => console.dir(res, { depth: null }))
 // HLTV.getMatchStats({id: 62979}).then(res => console.dir(res, { depth: null }))
 // HLTV.getTeam({ id: 9481 })
@@ -30,5 +30,5 @@ import HLTV from './index'
 // HLTV.getEvent({id: 3773}).then(res => console.dir(res, { depth: null })).catch(err => console.log(err))
 
 
-HLTV.getResults({pages: 1, eventId: 3883}).then(res => console.log(res))
-HLTV.getResults({pages: 1, eventId: 3047}).then(res => console.log(3047 + ':' + res.length))
+// HLTV.getResults({pages: 1, eventId: 3883}).then(res => console.log(res))
+// HLTV.getResults({pages: 1, eventId: 3047}).then(res => console.log(3047 + ':' + res.length))


### PR DESCRIPTION
A match can have different statuses depending on what happened: live, match over, sheduled(countdown timer is displayed) and match postponed. 
I added an enum with all the statuses and a property to the FullMatch interface.

This is helpful if you want to know if the match is still going to happen or is actually over. For example if there was a fortfeit, there is no result, the match is past it's date, but is still over.

I left the `live` property for backwards compatibility.

Examples:
- Postponed: [https://www.hltv.org/matches/2333181/-](https://www.hltv.org/matches/2333181/-)
- Over, due to withdraw of one team: [https://www.hltv.org/matches/2332985/-](https://www.hltv.org/matches/2332985/-)
