### PR TITLE
[WIP] Add httpAgent to HLTVConfig

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,19 @@
 import { defaultLoadPage } from './utils/mappers'
+import { Agent as httpsAgent } from 'https'
+import { Agent as httpAgent } from 'http'
 
 export interface HLTVConfig {
   hltvUrl?: string
   hltvStaticUrl?: string
   loadPage?: (url: string) => Promise<string>
+  httpAgent?: httpsAgent | httpAgent
 }
 
-export const defaultConfig = {
+const defaultAgent = new httpsAgent();
+
+export const defaultConfig: HLTVConfig = {
   hltvUrl: 'https://www.hltv.org',
   hltvStaticUrl: 'https://static.hltv.org',
-  loadPage: defaultLoadPage
+  httpAgent: defaultAgent,
+  loadPage: defaultLoadPage(defaultAgent),
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,15 +1,15 @@
 import { defaultLoadPage } from './utils/mappers'
-import { Agent as httpsAgent } from 'https'
-import { Agent as httpAgent } from 'http'
+import { Agent as HttpsAgent } from 'https'
+import { Agent as HttpAgent } from 'http'
 
 export interface HLTVConfig {
   hltvUrl?: string
   hltvStaticUrl?: string
   loadPage?: (url: string) => Promise<string>
-  httpAgent?: httpsAgent | httpAgent
+  httpAgent?: HttpsAgent | HttpAgent
 }
 
-const defaultAgent = new httpsAgent();
+const defaultAgent = new HttpsAgent();
 
 export const defaultConfig: HLTVConfig = {
   hltvUrl: 'https://www.hltv.org',

--- a/src/endpoints/connectToScorebot.ts
+++ b/src/endpoints/connectToScorebot.ts
@@ -28,7 +28,9 @@ export const connectToScorebot = (config: HLTVConfig) => ({
       .pop()!
     const matchId = $('#scoreboardElement').attr('data-scorebot-id')
 
-    const socket = io.connect(url)
+    const socket = io.connect(url, {
+      agent: !config.httpAgent
+    })
 
     const initObject = JSON.stringify({
       token: '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,9 +25,26 @@ import { ThreadCategory } from './enums/ThreadCategory'
 import { EventSize } from './enums/EventSize'
 import { WinType } from './enums/WinType'
 import { getEvents } from './endpoints/getEvents'
+import { defaultLoadPage } from './utils/mappers'
 
 export class HLTVFactory {
-  constructor(private readonly config: HLTVConfig) { }
+  constructor(private readonly config: HLTVConfig) {
+    if (!config.hltvStaticUrl) {
+      config.hltvStaticUrl = defaultConfig.hltvStaticUrl;
+    }
+    if (!config.hltvUrl) {
+      config.hltvUrl = defaultConfig.hltvUrl;
+    }
+    if (config.httpAgent && !config.loadPage) {
+      config.loadPage = defaultLoadPage(config.httpAgent);
+    }
+    if (!config.httpAgent) {
+      config.httpAgent = defaultConfig.httpAgent;
+    }
+    if (!config.loadPage) {
+      config.loadPage = defaultConfig.loadPage;
+    }
+  }
 
   connectToScorebot = connectToScorebot(this.config)
   getMatch = getMatch(this.config)

--- a/src/utils/mappers.ts
+++ b/src/utils/mappers.ts
@@ -6,10 +6,10 @@ import { Player } from '../models/Player'
 import { Outcome, WeakRoundOutcome } from '../models/RoundOutcome'
 import { MapSlug } from '../enums/MapSlug'
 import { popSlashSource } from '../utils/parsing'
-import { Agent as httpsAgent } from 'https'
-import { Agent as httpAgent } from 'http'
+import { Agent as HttpsAgent } from 'https'
+import { Agent as HttpAgent } from 'http'
 
-export const defaultLoadPage = (httpAgent: httpsAgent | httpAgent | undefined) => (url: string) =>
+export const defaultLoadPage = (httpAgent: HttpsAgent | HttpAgent | undefined) => (url: string) =>
   new Promise<string>(resolve => {
     request.get(url, { gzip: true, agent: httpAgent }, (_, __, body) => resolve(body))
   })

--- a/src/utils/mappers.ts
+++ b/src/utils/mappers.ts
@@ -6,10 +6,12 @@ import { Player } from '../models/Player'
 import { Outcome, WeakRoundOutcome } from '../models/RoundOutcome'
 import { MapSlug } from '../enums/MapSlug'
 import { popSlashSource } from '../utils/parsing'
+import { Agent as httpsAgent } from 'https'
+import { Agent as httpAgent } from 'http'
 
-export const defaultLoadPage = (url: string) =>
+export const defaultLoadPage = (httpAgent: httpsAgent | httpAgent | undefined) => (url: string) =>
   new Promise<string>(resolve => {
-    request.get(url, { gzip: true }, (_, __, body) => resolve(body))
+    request.get(url, { gzip: true, agent: httpAgent }, (_, __, body) => resolve(body))
   })
 
 export const fetchPage = async (


### PR DESCRIPTION
Related to #243 

So I've tried the solution we have been talking about. I am not sure how to setup the test for it, but I have been testing locally with our proxy and it seems to work fine. Unfortunately, it is a paid service and I am not able to commit the test with credentials.

The main drawback is that I had to change `defaultLoadPage` function to be higher order.
The other change I made is to treat missing properties of HLTVConfig as optional. If it is too much - I will revert the changes, but I found it a bit confusing when I've tried to use createInstance and found out that it doesn't tolerate missing properties.

Anyway, feel free to review the PR. I will continue testing scorebot meanwhile