### PR TITLE
Fix selector find betting provider on match page

### DIFF
--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -111,7 +111,7 @@ export const getMatch = (config: HLTVConfig) => async ({
     )
   }
 
-  const odds: OddResult[] = toArray($('.betting_provider:not(.hidden)'))
+  const odds: OddResult[] = toArray($('tr.provider:not(.hidden)'))
     .filter(hasNoChild('.noOdds'))
     .map(oddElement => {
       let convertOdds =


### PR DESCRIPTION
Fixes #248 - Sadly there is not really a test that is easy to add, as the current snapshot techniques do not work for bets. 
The bets are only present on matches that are not yet over and even there change a lot throughout a game. Therefor this PR does not come with tests other than to verify it by hand.