### PR TITLE
Fix ScoreboardPlayer deaths property name

### DIFF
--- a/src/models/ScoreboardUpdate.ts
+++ b/src/models/ScoreboardUpdate.ts
@@ -5,7 +5,7 @@ export interface ScoreboardPlayer {
   dbId: number
   name: string
   score: number
-  death: number
+  deaths: number
   assists: number
   alive: boolean
   money: number


### PR DESCRIPTION
Currently HLTV sends JSON with following structure:
```json
{
                "steamId": "1:0:41926534",
                "dbId": 7938,
                "name": "XANTARES",
                "score": 6,
                "deaths": 3,
                "assists": 0,
                "alive": true,
                "money": 2700,
                "damagePrRound": 95.66666666666667,
                "hp": 100,
                "primaryWeapon": "sg556",
                "kevlar": true,
                "helmet": true,
                "nick": "XANTARES",
                "hasDefusekit": false,
                "advancedStats": {
                    "kast": 5,
                    "entryKills": 1,
                    "entryDeaths": 0,
                    "multiKillRounds": 1,
                    "oneOnXWins": 0,
                    "flashAssists": 0
                }
            }
```

I've renamed death -> deaths