### PR TITLE
Fix getMatch(), Odds provider class changed name

### DIFF
--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -149,7 +149,7 @@ export const getMatch = (config: HLTVConfig) => async ({
       return {
         provider: oddElement
           .prop('class')
-          .split('geoprovider_')[1]
+          .split('gprov_')[1]
           .split(' ')[0]
           .trim(),
         team1: oddTeam1,


### PR DESCRIPTION
Odds provider HTML class changed name from:
"**geoprovider_**<provider_name> provider" to "**gprov_**<provider_name> provider"

Before the fix, the call to HLTV.getMatch() fails, the code should fix it again.