### PR TITLE
fix: Update getTeam enemyTeam.id logic

### DIFF
--- a/src/endpoints/getTeam.ts
+++ b/src/endpoints/getTeam.ts
@@ -1,7 +1,6 @@
 import { FullTeam, Result, Achievement } from '../models/FullTeam'
 import { HLTVConfig } from '../config'
 import { fetchPage, toArray } from '../utils/mappers'
-import { popSlashSource } from '../utils/parsing'
 
 export const getTeam = (config: HLTVConfig) => async ({
   id
@@ -41,9 +40,7 @@ export const getTeam = (config: HLTVConfig) => async ({
         .split('/')[2]
     ),
     enemyTeam: {
-      id: Number(
-        popSlashSource(matchEl.find('.team-2 .team-logo-container img'))!
-      ),
+      id: Number(matchEl.find('.team-2').attr('href').split('/')[2]),
       name: matchEl.find('span.team-2').text()
     },
     result: matchEl.find('.score-cell').text()


### PR DESCRIPTION
Currently, the `getTeam` endpoint throws an error:

```
Cannot read property 'split' of undefined
```

After a bit of digging, I found out that it was happening on this line: https://github.com/gigobyte/HLTV/blob/master/src/endpoints/getTeam.ts#L45

`popSlashSource` is looking for `.attr('src')` on an `img` that doesn't exist. Instead, `.team-row .team-2` is an `a` tag that has the team ID in its `href`, so I changed this line to parse the team ID from there.