### PR TITLE
Fix getTeam Ended Name Bug

### DIFF
--- a/src/endpoints/getTeam.ts
+++ b/src/endpoints/getTeam.ts
@@ -76,7 +76,7 @@ export const getTeam = (config: HLTVConfig) => async ({
     }))
     .concat(
       toArray(e$('.image-and-label[href*="event"]')).map((eventEl) => ({
-        name: eventEl.attr('title')!,
+        name: eventEl.find('span').text()!,
         id: Number(eventEl.attr('href')!.split('=').pop())
       }))
     )


### PR DESCRIPTION
* Fix the bug in getTeam that doesn't show the name of the event for ended events
    * Changed where it is located on hltv
* Added ended boolean so users can know if event is ongoing or ended

Closes #351