### PR TITLE
Added url parameter to getMatch() for circumventing instant throttling

### DIFF
--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -31,14 +31,13 @@ const getTeamId = (el: cheerio.Cheerio): number | undefined => {
 }
 
 export const getMatch = (config: HLTVConfig) => async ({
-  id
+  id,
+  url
 }: {
   id: number
+  url?: string 
 }): Promise<FullMatch> => {
-  const $ = await fetchPage(
-    `${config.hltvUrl}/matches/${id}/-`,
-    config.loadPage
-  )
+  const $ = url ? await fetchPage(`${config.hltvUrl}${url}`, config.loadPage) : await fetchPage(`${config.hltvUrl}/matches/${id}/-`, config.loadPage)
 
   checkForRateLimiting($)
 

--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -145,22 +145,20 @@ export const getMatch = (config: HLTVConfig) => async ({
 
   let oddsCommunity: CommunityOddResult | undefined
 
-  if ($('.pick-a-winner-team').length == 2) {
+  if ($('.pick-a-winner').length > 0) {
     oddsCommunity = {
       team1: percentageToDecimalOdd(
         Number(
-          $('.pick-a-winner-team')
-            .first()
-            .find('.percentage')
+          $('.pick-a-winner-team.team1>.percentage')
+            .first() // query returns two elements due to mobile version
             .text()
             .replace('%', '')
         )
       ),
       team2: percentageToDecimalOdd(
         Number(
-          $('.pick-a-winner-team')
-            .last()
-            .find('.percentage')
+          $('.pick-a-winner-team.team2>.percentage')
+            .first()
             .text()
             .replace('%', '')
         )

--- a/src/endpoints/getMatches.ts
+++ b/src/endpoints/getMatches.ts
@@ -16,7 +16,8 @@ export const getMatches = (config: HLTVConfig) => async (): Promise<
 
   const liveMatches: LiveMatch[] = toArray($('.liveMatch-container')).map(
     (matchEl) => {
-      const id = Number(matchEl.find('.a-reset').attr('href')!.split('/')[2])
+      const url = matchEl.find('.a-reset').attr('href')!
+      const id = Number(url.split('/')[2])
       const teamNameEls = matchEl.find('.matchTeamName')
       const stars = 5 - matchEl.find('.matchRating i.faded').length
 
@@ -40,14 +41,14 @@ export const getMatches = (config: HLTVConfig) => async (): Promise<
           ) || undefined
       }
 
-      return { id, team1, team2, event, format, stars, live: true }
+      return { id, url, team1, team2, event, format, stars, live: true }
     }
   )
 
   const upcomingMatches: UpcomingMatch[] = toArray($('.upcomingMatch')).map(
     (matchEl) => {
-      const link = matchEl.find('.a-reset')
-      const id = Number(link.attr('href')!.split('/')[2])
+      const url = matchEl.find('.a-reset').attr('href')!
+      const id = Number(url.split('/')[2])
       const date =
         Number(matchEl.find('.matchTime').attr('data-unix')) || undefined
       const title = matchEl.find('.matchInfoEmpty').text() || undefined
@@ -82,6 +83,7 @@ export const getMatches = (config: HLTVConfig) => async (): Promise<
 
       return {
         id,
+        url,
         date,
         team1,
         team2,

--- a/src/models/LiveMatch.ts
+++ b/src/models/LiveMatch.ts
@@ -3,6 +3,7 @@ import { Event } from './Event'
 
 export interface LiveMatch {
   readonly id: number
+  readonly url: string
   readonly team1: Team
   readonly team2: Team
   readonly format: string

--- a/src/models/UpcomingMatch.ts
+++ b/src/models/UpcomingMatch.ts
@@ -3,6 +3,7 @@ import { Event } from './Event'
 
 export interface UpcomingMatch {
   readonly id: number
+  readonly url: string
   readonly team1?: Team
   readonly team2?: Team
   readonly date?: number


### PR DESCRIPTION
I noticed that I get instantly blocked, i.e. on the first request, by HLTV for some matches when calling `getMatch()` but not when accessing the match manually. I suspected the different url being the reason. For instance, the API uses `https://www.hltv.org/matches/2346243/-` whereas HLTV actually links to `https://www.hltv.org/matches/2346243/lilmix-vs-exploit-snow-sweet-snow-1-regionals`. 

After adapting the code to additionally return the actual url and modifying `getMatch()` to accept an *optional* url parameter, the rate limiting errors disappeared immediately.