### PR TITLE
fixed mapslug

### DIFF
--- a/src/shared/GameMap.ts
+++ b/src/shared/GameMap.ts
@@ -36,7 +36,7 @@ export const fromMapSlug = (slug: string): GameMap => {
       return GameMap.Nuke
     case 'tcn':
       return GameMap.Tuscan
-    case 'vertigo':
+    case 'vtg':
       return GameMap.Vertigo
     case '-':
       return GameMap.Default


### PR DESCRIPTION
When using getMatchesStats and the map vertigo is played it triggers the default case of your switch. I've fixed that and now it works properly.
https://prnt.sc/111i40i