### PR TITLE
Fix type error Cannot read property 'split' of undefined in getMatch

### DIFF
--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -366,13 +366,16 @@ function getPlayers($: HLTVPage) {
       .find('.flagAlign')
       .toArray()
       .map(getMatchPlayer),
-    team2: $('div.players')
-      .last()
-      .find('tr')
-      .last()
-      .find('.flagAlign')
-      .toArray()
-      .map(getMatchPlayer)
+    team2:
+      $('div.players').length > 1
+        ? $('div.players')
+            .last()
+            .find('tr')
+            .last()
+            .find('.flagAlign')
+            .toArray()
+            .map(getMatchPlayer)
+        : []
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,7 @@ export function getIdAt(index?: number, href?: string): any {
     case 1:
       return (href: string) => getIdAt(index!, href)
     default:
-      return parseNumber(href!.split('/')[index!])
+      return href ? parseNumber(href!.split('/')[index!]) : undefined
   }
 }
 


### PR DESCRIPTION
This error occurs when the other team is missing/TBD.

Example match id 2347024. [HTML snapshot on 2021-04-05, 19:40 UTC in paste.ubuntu.com](https://paste.ubuntu.com/p/mxHSkS9s7v/).

This PR also fixes team2 players being incorrect (duplicate of team1) when the other team is missing.