### PR TITLE
fix view count of highlights & fix function crash

### DIFF
--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -160,7 +160,7 @@ export const getEvent = (config: HLTVConfig) => async ({
         .find('.video-team-img')
         .first()
         .attr('title')
-      const team1 = teams.find((x) => x.name === team1Name)!
+      const team1 = teams.find((x) => x.name === team1Name) || teams.find((x) => x.name == 'ex-'+team1Name) || { id: undefined, name: team1Name }
 
       const team2Name = el
         .find('.video-team')
@@ -168,9 +168,9 @@ export const getEvent = (config: HLTVConfig) => async ({
         .find('.video-team-img')
         .first()
         .attr('title')
-      const team2 = teams.find((x) => x.name === team2Name)!
+      const team2 = teams.find((x) => x.name === team2Name) || teams.find((x) => x.name == 'ex-' + team2Name) || { id: undefined, name: team2Name }
 
-      const views = Number($('.thumbnail-view-count').text().split(' ')[0])
+      const views = Number(el.find('.thumbnail-view-count').text().split(' ')[0])
 
       return {
         name,


### PR DESCRIPTION
Hey,

in some cases like [this](https://www.hltv.org/events/5786/snow-sweet-snow-3) a team switches their organisation with leads to HLTV giving them a new id and obviously another name. But in the highlights section, there are the original names used. Your functions tries to find the original name in the list of participants (where the new name is used). So I changed it: It first tries to add the `ex-` prefix. If there is still no matching team (because they already changed their whole name), it just sets the teamId to undefined, because I don't see a chance to get it from somewhere. Maybe you can find a way? 
Further, there was an issue with the view count which always showed the views of the first clip.

Thanks for your work!
