### PR TITLE
feat: add side to half result

### DIFF
--- a/__tests__/__snapshots__/getMatch.test.ts.snap
+++ b/__tests__/__snapshots__/getMatch.test.ts.snap
@@ -194,7 +194,24 @@ Object {
   "maps": Array [
     Object {
       "name": "de_dust2",
-      "result": undefined,
+      "result": Object {
+        "halfResults": Array [
+          Object {
+            "team1Rounds": 15,
+            "team1Side": "t",
+            "team2Rounds": 0,
+            "team2Side": "ct",
+          },
+          Object {
+            "team1Rounds": 1,
+            "team1Side": "ct",
+            "team2Rounds": 0,
+            "team2Side": "t",
+          },
+        ],
+        "team1TotalRounds": 16,
+        "team2TotalRounds": 0,
+      },
       "statsId": 73147,
     },
     Object {
@@ -203,11 +220,15 @@ Object {
         "halfResults": Array [
           Object {
             "team1Rounds": 5,
+            "team1Side": "t",
             "team2Rounds": 10,
+            "team2Side": "ct",
           },
           Object {
             "team1Rounds": 9,
+            "team1Side": "ct",
             "team2Rounds": 6,
+            "team2Side": "t",
           },
         ],
         "team1TotalRounds": 14,
@@ -221,11 +242,15 @@ Object {
         "halfResults": Array [
           Object {
             "team1Rounds": 7,
+            "team1Side": "ct",
             "team2Rounds": 8,
+            "team2Side": "t",
           },
           Object {
             "team1Rounds": 5,
+            "team1Side": "t",
             "team2Rounds": 8,
+            "team2Side": "ct",
           },
         ],
         "team1TotalRounds": 12,
@@ -566,11 +591,15 @@ Object {
         "halfResults": Array [
           Object {
             "team1Rounds": 8,
+            "team1Side": "ct",
             "team2Rounds": 7,
+            "team2Side": "t",
           },
           Object {
             "team1Rounds": 8,
+            "team1Side": "t",
             "team2Rounds": 2,
+            "team2Side": "ct",
           },
         ],
         "team1TotalRounds": 16,
@@ -584,15 +613,21 @@ Object {
         "halfResults": Array [
           Object {
             "team1Rounds": 6,
+            "team1Side": "t",
             "team2Rounds": 9,
+            "team2Side": "ct",
           },
           Object {
             "team1Rounds": 9,
+            "team1Side": "ct",
             "team2Rounds": 6,
+            "team2Side": "t",
           },
           Object {
             "team1Rounds": 16,
+            "team1Side": undefined,
             "team2Rounds": 11,
+            "team2Side": undefined,
           },
         ],
         "team1TotalRounds": 31,
@@ -861,11 +896,15 @@ Object {
         "halfResults": Array [
           Object {
             "team1Rounds": 6,
+            "team1Side": "t",
             "team2Rounds": 9,
+            "team2Side": "ct",
           },
           Object {
             "team1Rounds": 4,
+            "team1Side": "ct",
             "team2Rounds": 7,
+            "team2Side": "t",
           },
         ],
         "team1TotalRounds": 10,
@@ -879,11 +918,15 @@ Object {
         "halfResults": Array [
           Object {
             "team1Rounds": 4,
+            "team1Side": "ct",
             "team2Rounds": 11,
+            "team2Side": "t",
           },
           Object {
             "team1Rounds": 12,
+            "team1Side": "t",
             "team2Rounds": 2,
+            "team2Side": "ct",
           },
         ],
         "team1TotalRounds": 16,
@@ -897,11 +940,15 @@ Object {
         "halfResults": Array [
           Object {
             "team1Rounds": 9,
+            "team1Side": "t",
             "team2Rounds": 6,
+            "team2Side": "ct",
           },
           Object {
             "team1Rounds": 7,
+            "team1Side": "ct",
             "team2Rounds": 4,
+            "team2Side": "t",
           },
         ],
         "team1TotalRounds": 16,

--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -58,6 +58,8 @@ export interface ProviderOdds {
 export interface MapHalfResult {
   team1Rounds: number
   team2Rounds: number
+  team1Side: string | undefined
+  team2Side: string | undefined
 }
 
 export interface MapResult {
@@ -327,15 +329,31 @@ function getMaps($: HLTVPage): MapResult[] {
 
       let result
 
-      if (team1TotalRounds && team2TotalRounds) {
-        const halfsString = mapEl.find('.results-center-half-score').trimText()!
-        const halfs = halfsString
-          .split(' ')
-          .map((x) => x.replace(/\(|\)|;/g, ''))
-          .map((half) => ({
-            team1Rounds: Number(half.split(':')[0]),
-            team2Rounds: Number(half.split(':')[1])
-          }))
+      if (team1TotalRounds >= 0 && team2TotalRounds >= 0) {
+        const halfSpans = mapEl
+          .find('.results-center-half-score')
+          .children('span')
+          .toArray()
+        let halfIndex = 0
+        const halfs = []
+        const halfArrays: Array<Array<HLTVPageElement>> = [[]]
+        for (const span of halfSpans) {
+          const text = span.trimText()
+          const isNumber = Number(text)
+          if (isNumber >= 0) {
+            halfArrays[halfIndex].push(span)
+            if (halfArrays[halfIndex].length === 2) {
+              halfs.push({
+                team1Side: halfArrays[halfIndex][0].attr('class'),
+                team2Side: halfArrays[halfIndex][1].attr('class'),
+                team1Rounds: Number(halfArrays[halfIndex][0].trimText()),
+                team2Rounds: Number(halfArrays[halfIndex][1].trimText())
+              })
+              halfIndex++
+              halfArrays[halfIndex] = []
+            }
+          }
+        }
 
         result = {
           team1TotalRounds,


### PR DESCRIPTION
Hi, thanks for all the work you are doing on this project!
I've tried to make half results more informative by adding information on what side each of the teams have been playing. Now this is just a string, but I can create an enum. And also there was a small bug with half results when one number was 0 and it was treatead as false. 
