### PR TITLE
Fixed problem that endpoint was not get the event name and id

### DIFF
--- a/src/endpoints/getMatches.ts
+++ b/src/endpoints/getMatches.ts
@@ -49,11 +49,13 @@ export const getMatches =
       await fetchPage(`https://www.hltv.org/matches?${query}`, config.loadPage)
     )
 
-    const events = $('.event-filter-popup a')
+    const events = $('.events-container a')
       .toArray()
       .map((el) => ({
         id: el.attrThen('href', (x) => Number(x.split('=').pop())),
-        name: el.find('.event-name').text()
+        name: el.find('.event-name').text() !== '' 
+          ? el.find('.event-name').text() 
+          : el.find('.featured-event-tooltip-content').text()
       }))
 
     return $('.liveMatch-container')


### PR DESCRIPTION
Exists a error in endpoint getMatches that the three firsts events was not getted and return undefined. 
Was fixed changing the class event-filter-popup to events-container and adding a ternary condition to return the correct value.