### PR TITLE
added allMatchesListed property for events

### DIFF
--- a/src/endpoints/getEvent.ts
+++ b/src/endpoints/getEvent.ts
@@ -48,7 +48,8 @@ export interface FullEvent {
   dateEnd?: number
   prizePool: string
   location: Country
-  numberOfTeams?: number
+  numberOfTeams: number
+  allMatchesListed: boolean
   teams: FullEventTeam[]
   prizeDistribution: FullEventPrizeDistribution[]
   relatedEvents: Event[]
@@ -115,7 +116,9 @@ export const getEvent =
         }
       })
 
-    const numberOfTeams = $('td.teamsNumber').numFromText()!
+    const numberOfTeams = parseNumber($('td.teamsNumber').text().split("+")[0])!
+
+    const allMatchesListed = !$('td.teamsNumber').text().includes("+")!
 
     const teams = $('.team-box')
       .toArray()
@@ -201,6 +204,7 @@ export const getEvent =
       prizePool,
       location,
       numberOfTeams,
+      allMatchesListed,
       teams,
       prizeDistribution,
       relatedEvents,

--- a/src/endpoints/getEvents.ts
+++ b/src/endpoints/getEvents.ts
@@ -11,6 +11,7 @@ export interface EventPreview {
   dateStart: number
   dateEnd: number
   numberOfTeams?: number
+  allMatchesListed?: boolean
   prizePool?: string
   location?: Country
   featured: boolean
@@ -107,8 +108,10 @@ export const getEvents =
           .text()
 
         const numberOfTeams = parseNumber(
-          el.find('.additional-info tr').first().find('td').eq(2).text()
+          el.find('.additional-info tr').first().find('td').eq(2).text().split("+")[0]
         )
+
+        const allMatchesListed = !el.find('.additional-info tr').first().find('td').eq(2).text().includes("+")
 
         return {
           id,
@@ -118,6 +121,7 @@ export const getEvents =
           location,
           prizePool,
           numberOfTeams,
+          allMatchesListed,
           featured: true
         }
       })
@@ -156,8 +160,10 @@ export const getEvents =
 
         const prizePool = el.find('.prizePoolEllipsis').text()
         const numberOfTeams = parseNumber(
-          el.find('.prizePoolEllipsis').prev().text()
+          el.find('.prizePoolEllipsis').prev().text().split("+")[0]
         )
+
+        const allMatchesListed = !el.find('.prizePoolEllipsis').prev().text().includes("+")
 
         return {
           id,
@@ -167,6 +173,7 @@ export const getEvents =
           location,
           prizePool,
           numberOfTeams,
+          allMatchesListed,
           featured: false
         }
       })


### PR DESCRIPTION
Hey,

I've added a allMatchesListed property for events.

Some upcoming/past events look like this if not all matches of the event are listed on Hltv.
![grafik](https://user-images.githubusercontent.com/27867779/149192706-f648cacf-7f4b-4002-90ac-799b42b39708.png)

parseNumber failed on the `+` that's why I excluded it and added the property which will be true if there are more matches to the event (indicated by the `+`)
