### PR TITLE
Fix parsing 16-0 scores in getMatch

### DIFF
--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -329,7 +329,7 @@ function getMaps($: HLTVPage): MapResult[] {
 
       let result
 
-      if (team1TotalRounds && team2TotalRounds) {
+      if (!isNaN(team1TotalRounds) && !isNaN(team2TotalRounds)) {
         const halfsString = mapEl.find('.results-center-half-score').trimText()!
         const halfs = halfsString
           .split(' ')


### PR DESCRIPTION
This change fixes the current if-statement which ignores scores if one of them is 0 and thus never returns 16-0 map round scores.