### PR TITLE
Fixing selector for overall map stats table

### DIFF
--- a/src/endpoints/getMatchMapStats.ts
+++ b/src/endpoints/getMatchMapStats.ts
@@ -387,12 +387,12 @@ export function getPlayerStats(m$: HLTVPage, p$: HLTVPage) {
   }
 
   return {
-    team1: m$('.stats-table')
+    team1: m$('.stats-table.totalstats')
       .first()
       .find('tbody tr')
       .toArray()
       .map(getPlayerOverviewStats),
-    team2: m$('.stats-table')
+    team2: m$('.stats-table.totalstats')
       .last()
       .find('tbody tr')
       .toArray()


### PR DESCRIPTION
Hey!

I found a bug for getMatchMapStats endpoint.
If you call this endpoint for example for id: _147841_ you will receive badly parsed data for players array.

**What you receive now (wrong - only T side):**
`     ...{
        player: { id: 16435, name: 'capseN' },
        kills: 7,
        hsKills: 1,
        assists: 0,
        flashAssists: 0,
        deaths: 5,
        KAST: 73.3,
        killDeathsDifference: 2,
        ADR: 41.7,
        firstKillsDifference: -1,
        rating1: 1.08
      }...`


**What you will receive after this change (correct - both sides):**
`...      {
        player: { id: 16435, name: 'capseN' },
        kills: 9,
        hsKills: 1,
        assists: 0,
        flashAssists: 0,
        deaths: 6,
        KAST: 72.2,
        killDeathsDifference: 3,
        ADR: 39.2,
        firstKillsDifference: -2,
        rating1: 1.02
      }...`

This PR fixing parsing problem by additional class selector of the correct table [URL](https://www.hltv.org/stats/matches/mapstatsid/147841/titans-vs-1win).