### PR TITLE
Fix bug in getPlayer/getPlayerByName method.

### DIFF
--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -331,15 +331,18 @@ function getMaps($: HLTVPage): MapResult[] {
 
       if (!isNaN(team1TotalRounds) && !isNaN(team2TotalRounds)) {
         const halfsString = mapEl.find('.results-center-half-score').trimText()!
-        let halfs = [{team1Rounds: 0, team2Rounds: 0}, {team1Rounds: 0, team2Rounds: 0}]
+        let halfs = [
+          { team1Rounds: 0, team2Rounds: 0 },
+          { team1Rounds: 0, team2Rounds: 0 }
+        ]
         if (halfsString) {
-            halfs = halfsString
-              .split(' ')
-              .map((x) => x.replace(/\(|\)|;/g, ''))
-              .map((half) => ({
-                team1Rounds: Number(half.split(':')[0]),
-                team2Rounds: Number(half.split(':')[1])
-              }))
+          halfs = halfsString
+            .split(' ')
+            .map((x) => x.replace(/\(|\)|;/g, ''))
+            .map((half) => ({
+              team1Rounds: Number(half.split(':')[0]),
+              team2Rounds: Number(half.split(':')[1])
+            }))
         }
 
         result = {

--- a/src/endpoints/getPlayer.ts
+++ b/src/endpoints/getPlayer.ts
@@ -69,8 +69,8 @@ export const getPlayer =
       : $('.bodyshot-img').attr('src')
 
     const image =
-      imageUrl.includes('bodyshot/unknown.png') ||
-      imageUrl.includes('static/player/player_silhouette.png')
+      imageUrl?.includes('bodyshot/unknown.png') ||
+      imageUrl?.includes('static/player/player_silhouette.png')
         ? undefined
         : imageUrl
 


### PR DESCRIPTION
This pull request fixes a bug when calling the `getPlayerByName` method with a player name `fl0m`. The bug was caused by a `TypeError` that occurred when trying to read properties of undefined, specifically when trying to access the includes method of a nullable imageUrl property.

To fix this issue, I added optional chaining to the imageUrl property, so that the code will check if the property exists before trying to access its methods.