### PR TITLE
Add Team Rank to the Match Team Object

### DIFF
--- a/src/endpoints/getMatch.ts
+++ b/src/endpoints/getMatch.ts
@@ -196,7 +196,8 @@ function getTeam($: HLTVPage, n: 1 | 2): Team | undefined {
         name: $(`.team${n}-gradient .teamName`).text(),
         id: $(`.team${n}-gradient a`).attrThen('href', (href) =>
           href ? getIdAt(2, href) : undefined
-        )
+        ),
+        rank: Number($(".teamRanking").toArray()[n-1].text().replace(/[^0-9]/g, ''))
       }
     : undefined
 }

--- a/src/shared/Team.ts
+++ b/src/shared/Team.ts
@@ -1,4 +1,5 @@
 export interface Team {
   name: string
   id?: number
+  rank?: number
 }


### PR DESCRIPTION
Adding in the team rank for at the time of the match

*Can now see the ranks at the time of the match instead of only in real time via getTeam
*If rank is undefined, shows up as a rank of 0

<img width="403" alt="Screenshot 2023-09-08 at 9 46 37 AM" src="https://github.com/gigobyte/HLTV/assets/4715098/7ddab5fa-3a3e-4812-8652-6a80730a99cf">