### PR TITLE
Add link to match page in getMatches() response

### DIFF
--- a/src/endpoints/getMatches.ts
+++ b/src/endpoints/getMatches.ts
@@ -77,6 +77,7 @@ export const getMatches =
         const stars = 5 - el.find('.matchRating i.faded').length
         const live = el.find('.matchTime.matchLive').text() === 'LIVE'
         const title = el.find('.matchInfoEmpty').text() || undefined
+        const linkToMatch = el.find('.a-reset').attr('href')
 
         const date = el.find('.matchTime').numFromAttr('data-unix')
 
@@ -104,6 +105,17 @@ export const getMatches =
         const eventName = el.find('.matchEventLogo').attr('title')
         const event = events.find((x) => x.name === eventName)
 
-        return { id, date, stars, title, team1, team2, format, event, live }
+        return {
+          id,
+          date,
+          stars,
+          title,
+          team1,
+          team2,
+          format,
+          event,
+          live,
+          linkToMatch
+        }
       })
   }


### PR DESCRIPTION
Hello there, first of all: Thank you !

When you click on a match from the Matches page, the redirect URL is kind of not intuitive, there are some logics and concatenations from HLTV. Team names are cleaned (Virtus.pro --> virtuspro) for example.
We can find the logic and implement it but It's a bit error prone. By having the value from the response, we could make clean redirectToMatch URL 👍 

My purpose is to add the `href` value in the  `getMatches()` response in order to be able to create redirect link easily 🤷 

Thank you in advance.



