### PR TITLE
Dependency fix and allowing for added repo directly to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
+    "prepare": "tsc -p tsconfig.release.json",
     "build": "tsc -p tsconfig.release.json",
     "start": "ts-node src/playground",
     "test": "jest --runInBand",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "cheerio": "1.0.0",
-    "got-scraping": "4.1.1",
+    "got-scraping": "3.2.15",
     "socket.io-client": "2.4.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,11 +10,11 @@
     // "allowJs": true,                             /* Allow javascript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
-    "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+    "declaration": false,                         /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                           /* Generates corresponding '.map' file. */
     // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    "outDir": "./lib",                              /* Redirect output structure to the directory. */
+    "outDir": "lib",                              /* Redirect output structure to the directory. */
     // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */


### PR DESCRIPTION
 The dependency got-scraping must be locked to version 3.2.15 since version 4.0.0 requires js modules. The current codebase generates common js from the typescript leading to an error when using the package.
 
 Additionally I have added a prepare script to the package.json to allow for npm install directly from this git repo. This also requires turning off declarations, I believe this to be a bug with typescript for npm, unsure which is responsible. 
 
 I understand that this project is unmaintained but I'd like at least the first part to be merged for the usability of legacy projects like this. I'd also advise to archive the project if no further updates are planned. Thank you for your time.